### PR TITLE
refactor(tokens table): make it easier to find figma tokens in the to…

### DIFF
--- a/packages/admin-ui-docs/src/components/TokensTable/index.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/index.tsx
@@ -46,6 +46,10 @@ export function TokensTable(props: TokensTableProps) {
           : includesSearchedText(item.value.stringfied, searchLowerCase)
 
       return (
+        includesSearchedText(
+          item.formatedToken,
+          searchLowerCase.replace(/\s|\//g, '.')
+        ) ||
         includesSearchedText(item.token, searchLowerCase) ||
         includesSearchedText(item.type, searchLowerCase) ||
         isSearchedTextInValueColumn
@@ -172,6 +176,7 @@ type TextValueProp = {
 interface TokensTableProps {
   items: Array<{
     token: string
+    formatedToken: string
     description: string
     value: string | TextValueProp
     type: string

--- a/packages/admin-ui-docs/src/components/TokensTable/index.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/index.tsx
@@ -47,7 +47,7 @@ export function TokensTable(props: TokensTableProps) {
 
       return (
         includesSearchedText(
-          item.formatedToken,
+          item.formattedToken,
           searchLowerCase.replace(/\s|\//g, '.')
         ) ||
         includesSearchedText(item.token, searchLowerCase) ||
@@ -176,7 +176,7 @@ type TextValueProp = {
 interface TokensTableProps {
   items: Array<{
     token: string
-    formatedToken: string
+    formattedToken: string
     description: string
     value: string | TextValueProp
     type: string

--- a/packages/admin-ui-docs/src/components/TokensTable/index.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/index.tsx
@@ -13,10 +13,29 @@ import {
 } from '@vtex/admin-ui'
 import { FilterDataGrid } from '../FilterDataGrid'
 
+type Item = {
+  token: string
+  formattedToken: string
+}
+
 const filters = ['All', 'Background', 'Color', 'Border', 'BoxShadow', 'Text']
 
 const includesSearchedText = (columnText: string, searchedText: string) =>
   columnText.toLowerCase().includes(searchedText)
+
+const includesSearchedTokens = (columnText: string, searchedTokes: string[]) =>
+  searchedTokes.reduce(
+    (acc, current) => acc && columnText.toLowerCase().includes(current),
+    true
+  )
+
+const includesSearchedTextInTokenColumn = (item: Item, searchedText: string) =>
+  includesSearchedText(item.token, searchedText) ||
+  includesSearchedText(
+    item.formattedToken,
+    searchedText.replace(/\s|\//g, '.')
+  ) ||
+  includesSearchedTokens(item.formattedToken, searchedText.split(/\s|\//g))
 
 export function TokensTable(props: TokensTableProps) {
   const dataView = useDataViewState()
@@ -46,11 +65,7 @@ export function TokensTable(props: TokensTableProps) {
           : includesSearchedText(item.value.stringfied, searchLowerCase)
 
       return (
-        includesSearchedText(
-          item.formattedToken,
-          searchLowerCase.replace(/\s|\//g, '.')
-        ) ||
-        includesSearchedText(item.token, searchLowerCase) ||
+        includesSearchedTextInTokenColumn(item, searchLowerCase) ||
         includesSearchedText(item.type, searchLowerCase) ||
         isSearchedTextInValueColumn
       )

--- a/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
@@ -22,6 +22,7 @@ function createMap(
 
     return {
       token: `$${extractTokenCall(token)}`,
+      formatedToken,
       description: '',
       value: fotmatValue(get(defaultTheme, formatedToken, '-')),
       type: prop,

--- a/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
@@ -15,7 +15,7 @@ import {
 function createMap(
   prop: string,
   tokenCall: string,
-  fotmatValue = (v: any) => v
+  formatValue = (v: any) => v
 ) {
   return function map(token: string) {
     const formattedToken = `${tokenCall}.${extractTokenCall(token)}`
@@ -24,7 +24,7 @@ function createMap(
       token: `$${extractTokenCall(token)}`,
       formattedToken,
       description: '',
-      value: fotmatValue(get(defaultTheme, formattedToken, '-')),
+      value: formatValue(get(defaultTheme, formattedToken, '-')),
       type: prop,
       csx: {
         [`${prop}`]: token,

--- a/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
@@ -18,13 +18,13 @@ function createMap(
   fotmatValue = (v: any) => v
 ) {
   return function map(token: string) {
-    const formatedToken = `${tokenCall}.${extractTokenCall(token)}`
+    const formattedToken = `${tokenCall}.${extractTokenCall(token)}`
 
     return {
       token: `$${extractTokenCall(token)}`,
-      formatedToken,
+      formattedToken,
       description: '',
-      value: fotmatValue(get(defaultTheme, formatedToken, '-')),
+      value: fotmatValue(get(defaultTheme, formattedToken, '-')),
       type: prop,
       csx: {
         [`${prop}`]: token,


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
"Translate" figma tokens to find correct tokens in the Design Tokens table

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
We are having some misunderstanding when we try to find the figma tokens in the **[Design Tokens table](https://admin-ui-git-refactor-filter-design-tokens-styleguide-core.vercel.app/guidelines/design-tokens)** because the naming is slightly different

Figma token: `bg.action/main.secondary` 
Real token: `$action.main.secondary`

#### How should this be manually tested?
Just try to find the token `$action.main.secondary` using `bg.action/main.secondary` 

#### Screenshots or example usage
<!-- Add screenshots that display the effects of your PR, especially when then involve visible aspects. -->

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
![4HOB](https://user-images.githubusercontent.com/991309/152215167-e7d56c53-20ec-477b-9312-4aace97ddc2e.gif)