### PR TITLE
fix(toast component): fix toast component width and position for mobile devices

### DIFF
--- a/packages/admin-ui/src/components/Toast/components/ToastQueue.tsx
+++ b/packages/admin-ui/src/components/Toast/components/ToastQueue.tsx
@@ -26,13 +26,17 @@ export function ToastQueue(props: ToastQueueProps) {
         pointerEvents: 'none',
         paddingX: 2,
         bottom: '3rem',
-        right: '2rem',
+        right: '0%',
         textAlign: 'center',
         marginLeft: 'auto',
-        width: '23.375rem',
+        width: '100%',
         listStyle: 'none',
         '> *:not(:last-child)': {
           marginBottom: '0.75rem',
+        },
+        '@tablet': {
+          right: '2rem',
+          width: '23.375rem',
         },
       }}
     >


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix toast component width for mobile Devices

#### How should this be manually tested?
Test the toast between 360px and 1200+px, see if it will break

#### Screenshots or example usage
Before this PR sample. (Easily to reproduce it by testing it on mobile < 360px)
![image](https://user-images.githubusercontent.com/8990835/154578114-449ac2c0-ede7-4c6f-afed-5c717f7a9b30.png)


#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
![GIF](https://media0.giphy.com/media/ORjfgiG9ZtxcQQwZzv/giphy.gif?cid=ecf05e47afz24rl6kjt8ucvmtm0uc0k1w5cfimcpk3hiw9w8&rid=giphy.gif&ct=g)
