### PR TITLE
build(phosphor-icons): bump icons to version 0.2.3

### DIFF
--- a/packages/admin-ui-react/package.json
+++ b/packages/admin-ui-react/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/react-helmet": "^6.1.5",
     "@vtex/admin-ui-core": "^0.5.1",
-    "@vtex/phosphor-icons": "0.2.2"
+    "@vtex/phosphor-icons": "0.2.3"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.1.0",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -53,7 +53,7 @@
     "@vtex/admin-ui-core": "^0.5.1",
     "@vtex/admin-ui-hooks": "^0.1.4",
     "@vtex/admin-ui-react": "^0.5.1",
-    "@vtex/phosphor-icons": "0.2.2",
+    "@vtex/phosphor-icons": "0.2.3",
     "csstype": "3.0.10",
     "downshift": "^6.0.6",
     "framer-motion": "^2.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6556,10 +6556,10 @@
     "@typescript-eslint/types" "4.28.5"
     eslint-visitor-keys "^2.0.0"
 
-"@vtex/phosphor-icons@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@vtex/phosphor-icons/-/phosphor-icons-0.2.2.tgz#3d31ce92d5b977ac83394f8a2002adbde08837d3"
-  integrity sha512-//OET6ezTBOgoRPXCgYrybARhRrrTAgRQoypEle3Gp3FUE8FWtL2lwkUy7AHKJ40kR3WhehA8Y7QkHJiAzbygg==
+"@vtex/phosphor-icons@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@vtex/phosphor-icons/-/phosphor-icons-0.2.3.tgz#79f8708ec445f882bede683c54d6819b88a09786"
+  integrity sha512-CtxO2Th3rJ6LBQ7mI8vvjoJLf3CPhu//Tys8zaVc/AheU1ISGK1GT+xfStM3XEnHZkfo94ofEL9mQXnABDA6UQ==
   dependencies:
     tiny-invariant "^1.1.0"
 


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Update **@vtex/phosphor-icons** version to improve tree-shaking for icons

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
