### PR TITLE
build: bump icons version to 0.2.5

### DIFF
--- a/packages/admin-ui-react/package.json
+++ b/packages/admin-ui-react/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/react-helmet": "^6.1.5",
     "@vtex/admin-ui-core": "^0.5.1",
-    "@vtex/phosphor-icons": "0.2.3"
+    "@vtex/phosphor-icons": "0.2.5"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.1.0",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -53,7 +53,7 @@
     "@vtex/admin-ui-core": "^0.5.1",
     "@vtex/admin-ui-hooks": "^0.1.4",
     "@vtex/admin-ui-react": "^0.5.2",
-    "@vtex/phosphor-icons": "0.2.3",
+    "@vtex/phosphor-icons": "0.2.5",
     "csstype": "3.0.10",
     "downshift": "^6.0.6",
     "framer-motion": "^2.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6556,10 +6556,10 @@
     "@typescript-eslint/types" "4.28.5"
     eslint-visitor-keys "^2.0.0"
 
-"@vtex/phosphor-icons@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@vtex/phosphor-icons/-/phosphor-icons-0.2.3.tgz#79f8708ec445f882bede683c54d6819b88a09786"
-  integrity sha512-CtxO2Th3rJ6LBQ7mI8vvjoJLf3CPhu//Tys8zaVc/AheU1ISGK1GT+xfStM3XEnHZkfo94ofEL9mQXnABDA6UQ==
+"@vtex/phosphor-icons@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@vtex/phosphor-icons/-/phosphor-icons-0.2.5.tgz#fdbfc54b3d7a2278353934fca3f4b08bff9ee1c4"
+  integrity sha512-dRx96Kb7IVnYqYbHrvFD9KgNyupscCDyOpn2mcwHzm2qDvxz2AEOQlkc8BRoQQNM/vWvQqmPYx30wmyAtqWpzw==
   dependencies:
     tiny-invariant "^1.1.0"
 


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Update @vtex/phosphor-icons version to improve bundle size of admin-ui

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
![confused-counting](https://user-images.githubusercontent.com/991309/155331531-0e7f681e-13af-48f4-8716-813e2020b593.gif)

