### PR TITLE
refactor(search-box): update color tokens and not display label while…

### DIFF
--- a/packages/admin-ui/src/components/SearchBox/SearchBox.style.ts
+++ b/packages/admin-ui/src/components/SearchBox/SearchBox.style.ts
@@ -54,14 +54,18 @@ const option = (highlighted: boolean) =>
       border: 'none',
       marginBottom: 2,
     },
-    bg: highlighted ? '$action.main.tertiarySelected' : '$action.main.tertiary',
+    bg: highlighted
+      ? '$action.neutral.tertiaryHover'
+      : '$action.neutral.tertiary',
     color: highlighted
-      ? '$action.main.tertiarySelected'
-      : '$action.main.tertiary',
-    svg: {
-      color: highlighted
-        ? '$action.main.tertiarySelected'
-        : '$action.main.tertiary',
+      ? '$action.neutral.tertiaryHover'
+      : '$action.neutral.tertiary',
+    svg: highlighted
+      ? '$action.neutral.tertiaryHover'
+      : '$action.neutral.tertiary',
+    ':active': {
+      color: '$action.neutral.tertiaryPressed',
+      background: '$action.neutral.tertiaryPressed',
     },
   })
 

--- a/packages/admin-ui/src/components/SearchBox/index.tsx
+++ b/packages/admin-ui/src/components/SearchBox/index.tsx
@@ -117,7 +117,7 @@ function Input(props: InputProps) {
       {inputProps?.value !== '' && (
         <Button
           csx={style.inputButton}
-          variant="tertiary"
+          variant="adaptative-dark"
           icon={<IconXCircle />}
           onClick={handleClear}
         />
@@ -154,7 +154,7 @@ function Menu(props: MenuProps) {
       {displaySuggestions && (
         <motion.p className={cn(style.label)} layout>
           <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-            <Intl id={type === 'search' ? 'adminPages' : 'lastSearches'} />
+            {type !== 'search' && <Intl id="lastSearches" />}
           </motion.span>
         </motion.p>
       )}


### PR DESCRIPTION
… searching

<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
 Update SearchBox color tokens and not display label while the user is searching for something
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Improve the use of global search in the admin shell

#### Screenshots or example usage
<!-- Add screenshots that display the effects of your PR, especially when then involve visible aspects. -->

https://user-images.githubusercontent.com/991309/157497740-a7d9859c-7719-4cc5-a284-e9b98f2a94b7.mov

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly