### PR TITLE
fix(bundle-size): remove framer-motion dependency to reduce bundle size

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -60,7 +60,6 @@
     "csstype": "3.0.10",
     "date-fns": "^2.28.0",
     "downshift": "^6.0.6",
-    "framer-motion": "^2.9.4",
     "react-collapsed": "^3.3.0",
     "react-device-detect": "^1.15.0",
     "react-is": "^17.0.1",

--- a/packages/admin-ui/src/components/SearchBox/index.tsx
+++ b/packages/admin-ui/src/components/SearchBox/index.tsx
@@ -1,15 +1,12 @@
 import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from 'react'
 import React, { cloneElement, Fragment } from 'react'
-import { useSystem, IconContainer } from '@vtex/admin-ui-react'
+import { useSystem, IconContainer, tag } from '@vtex/admin-ui-react'
 import { merge } from '@vtex/admin-ui-util'
 import {
   IconMagnifyingGlass,
   IconXCircle,
   IconClockCounterClockwise,
 } from '@vtex/phosphor-icons'
-
-import type { Variants } from 'framer-motion'
-import { motion, AnimateSharedLayout } from 'framer-motion'
 
 import { Button } from '../Button'
 import type { SystemComponent } from '../../types'
@@ -23,18 +20,6 @@ import { Paragraph } from '../Paragraph'
 
 export { unstableUseSearchBoxState } from './hooks/useSearchBoxState'
 
-const itemMotion: Variants = {
-  init: {
-    opacity: 0,
-  },
-  enter: {
-    opacity: 1,
-  },
-  leave: {
-    opacity: 0,
-  },
-}
-
 interface SearchBoxProps {
   state: any
   children?: ReactNode
@@ -43,30 +28,19 @@ interface SearchBoxProps {
 
 function __SearchBox(props: SearchBoxProps) {
   const { children, state, locale = 'en-US' } = props
-  const { cn } = useSystem()
 
   const labelProps = state.combobox.getLabelProps()
 
   return (
     <LocaleProvider value={locale}>
-      <AnimateSharedLayout>
-        <motion.div
-          layout
-          initial={{
-            originY: 'unset',
-          }}
-          className={cn(style.box)}
-        >
-          <VisuallyHidden>
-            <label {...labelProps}>
-              <Intl id="comboboxLabel" />
-            </label>
-          </VisuallyHidden>
-          <StateContext.Provider value={state}>
-            {children}
-          </StateContext.Provider>
-        </motion.div>
-      </AnimateSharedLayout>
+      <tag.div csx={style.box}>
+        <VisuallyHidden>
+          <label {...labelProps}>
+            <Intl id="comboboxLabel" />
+          </label>
+        </VisuallyHidden>
+        <StateContext.Provider value={state}>{children}</StateContext.Provider>
+      </tag.div>
     </LocaleProvider>
   )
 }
@@ -77,7 +51,6 @@ interface InputProps extends ComponentPropsWithoutRef<'input'> {
 
 function Input(props: InputProps) {
   const { onClear, onFocus, ...elementProps } = props
-  const { cn } = useSystem()
   const { intl } = useLocale()
 
   const {
@@ -105,14 +78,14 @@ function Input(props: InputProps) {
   }
 
   return (
-    <motion.div {...comboboxProps} className={cn(style.inputContainer)} layout>
+    <tag.div {...comboboxProps} csx={style.inputContainer}>
       <IconMagnifyingGlass csx={style.inputIcon} />
-      <input
+      <tag.input
         {...inputProps}
         {...elementProps}
         placeholder={intl('placeholder')}
         onFocus={handleFocus}
-        className={cn(style.input(isOpen, type === 'seed'))}
+        csx={style.input(isOpen, type === 'seed')}
       />
       {inputProps?.value !== '' && (
         <Button
@@ -122,7 +95,7 @@ function Input(props: InputProps) {
           onClick={handleClear}
         />
       )}
-    </motion.div>
+    </tag.div>
   )
 }
 
@@ -139,26 +112,25 @@ function Menu(props: MenuProps) {
     collection: { items, type },
   } = useStateContext()
 
-  const { cn } = useSystem()
-
   const menuProps = getMenuProps()
   const seed = type === 'seed'
   const empty = items.length === 0
   const displayScrollBar = !seed && items.length > 10
   const displayEmptyView = !seed && empty && isOpen
   const displaySuggestions = !seed && !empty && isOpen
-  const className = cn(merge(style.menu(displayScrollBar), csx))
 
   return (
     <Label>
       {displaySuggestions && (
-        <motion.p className={cn(style.label)} layout>
-          <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-            {type !== 'search' && <Intl id="lastSearches" />}
-          </motion.span>
-        </motion.p>
+        <tag.p csx={style.label}>
+          <tag.span>{type !== 'search' && <Intl id="lastSearches" />}</tag.span>
+        </tag.p>
       )}
-      <motion.ul {...menuProps} {...elementProps} layout className={className}>
+      <tag.ul
+        {...menuProps}
+        {...elementProps}
+        csx={merge(style.menu(displayScrollBar), csx)}
+      >
         {displayEmptyView && <EmptyView />}
         {displaySuggestions &&
           items.map((item: any, index: number) => {
@@ -174,30 +146,33 @@ function Menu(props: MenuProps) {
               </Fragment>
             )
           })}
-      </motion.ul>
+      </tag.ul>
     </Label>
   )
 }
 
 function EmptyView() {
-  const { cn } = useSystem()
+  const { keyframes } = useSystem()
+
+  const fadeIn = keyframes`
+    0% { opacity: 0 }
+    100% { opacity: 1 }
+  `
 
   return (
-    <motion.li
-      layout
-      className={cn(style.emptyContainer)}
-      variants={itemMotion}
-      initial="init"
-      animate="enter"
-      exit="leave"
+    <tag.li
+      csx={{
+        ...style.emptyContainer,
+        animation: `${fadeIn} 0.3s`,
+      }}
     >
-      <motion.p layout className={cn(style.emptyTitle)}>
+      <tag.p csx={style.emptyTitle}>
         <Intl id="emptyTitle" />
-      </motion.p>
-      <motion.p layout className={cn(style.emptySubtitle)}>
+      </tag.p>
+      <tag.p csx={style.emptySubtitle}>
         <Intl id="emptySubtitle" />
-      </motion.p>
-    </motion.li>
+      </tag.p>
+    </tag.li>
   )
 }
 
@@ -229,20 +204,22 @@ function Suggestion(props: SuggestionProps) {
     collection: { type },
   } = useStateContext()
 
-  const { cn } = useSystem()
-  const className = cn(merge(style.option(highlighted), csx))
+  const { keyframes } = useSystem()
   const liProps = getItemProps({ item, index })
 
+  const fadeIn = keyframes`
+    0% { opacity: 0 }
+    100% { opacity: 1 }
+  `
+
   return (
-    <motion.li
+    <tag.li
       {...liProps}
       {...elementProps}
-      layout
-      className={className}
-      variants={itemMotion}
-      initial="init"
-      animate="enter"
-      exit="leave"
+      csx={{
+        animation: `${fadeIn} 0.3s`,
+        ...merge(style.option(highlighted), csx),
+      }}
     >
       <IconContainer size="regular">
         {type === 'storage' && (
@@ -260,7 +237,7 @@ function Suggestion(props: SuggestionProps) {
       >
         {children ? children(item) : item}
       </Paragraph>
-    </motion.li>
+    </tag.li>
   )
 }
 
@@ -272,9 +249,7 @@ type KbdProps = ComponentPropsWithoutRef<'kbd'>
  * <Kbd>enter</Kbd>
  */
 function Kbd(props: KbdProps) {
-  const { cn } = useSystem()
-
-  return <motion.kbd className={cn(style.kbd)} {...(props as any)} layout />
+  return <tag.kbd csx={style.kbd} {...(props as any)} />
 }
 
 /**
@@ -285,39 +260,23 @@ function Kbd(props: KbdProps) {
  * </SearchBox>
  */
 function Footer() {
-  const { cn } = useSystem()
   const {
     combobox: { isOpen },
     collection: { type },
   } = useStateContext()
 
   return type !== 'seed' && isOpen ? (
-    <motion.footer
-      layout
-      variants={itemMotion}
-      initial="init"
-      animate="enter"
-      transition={{
-        enter: {
-          delay: 0.38,
-        },
-        leave: {
-          delay: 0.15,
-        },
-      }}
-      exit="leave"
-      className={cn(style.footer)}
-    >
-      <motion.div layout>
+    <tag.footer csx={style.footer}>
+      <tag.div>
         <Kbd>↓</Kbd> <Kbd>↑</Kbd> <Intl id="toNavigate" />
-      </motion.div>
-      <motion.div layout>
+      </tag.div>
+      <tag.div>
         <Kbd>enter</Kbd> <Intl id="toSelect" />
-      </motion.div>
-      <motion.div layout>
+      </tag.div>
+      <tag.div>
         <Kbd>esc</Kbd> <Intl id="toCancel" />
-      </motion.div>
-    </motion.footer>
+      </tag.div>
+    </tag.footer>
   ) : null
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,7 +2993,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.2", "@emotion/is-prop-valid@^0.8.6":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.6":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -12278,26 +12278,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^2.9.4:
-  version "2.9.5"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-2.9.5.tgz#bbb185325d531c57f494cf3f6cf7719fc2c225c7"
-  integrity sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==
-  dependencies:
-    framesync "^4.1.0"
-    hey-listen "^1.0.8"
-    popmotion "9.0.0-rc.20"
-    style-value-types "^3.1.9"
-    tslib "^1.10.0"
-  optionalDependencies:
-    "@emotion/is-prop-valid" "^0.8.2"
-
-framesync@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.1.0.tgz#69a8db3ca432dc70d6a76ba882684a1497ef068a"
-  integrity sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==
-  dependencies:
-    hey-listen "^1.0.5"
-
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -13210,11 +13190,6 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-hey-listen@^1.0.5, hey-listen@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
-  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 highlight.js@^10.1.1, highlight.js@~10.5.0:
   version "10.5.0"
@@ -17652,16 +17627,6 @@ polished@^4.1.4:
   dependencies:
     "@babel/runtime" "^7.16.7"
 
-popmotion@9.0.0-rc.20:
-  version "9.0.0-rc.20"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-rc.20.tgz#f3550042ae31957b5416793ae8723200951ad39d"
-  integrity sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==
-  dependencies:
-    framesync "^4.1.0"
-    hey-listen "^1.0.8"
-    style-value-types "^3.1.9"
-    tslib "^1.10.0"
-
 portfinder@^1.0.28:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -20927,14 +20892,6 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
-
-style-value-types@^3.1.9:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.2.0.tgz#eb89cab1340823fa7876f3e289d29d99c92111bb"
-  integrity sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==
-  dependencies:
-    hey-listen "^1.0.8"
-    tslib "^1.10.0"
 
 stylehacks@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
As the title says.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

The framer-motion lib is only being used on the `SearchBox` component and the problem is that this dep has a bundle size of ~95kb which significantly increases the total bundle of Admin UI

#### How should this be manually tested?
<!--- Usually `yarn and yarn test`, but feel encouraged to add a more descriptive explanation. -->
You can compare the [previous animation](https://620e870c28c4ae003a705d42-wgqbiqipek.chromatic.com/?path=/story/admin-ui-searchbox--basic) with the new one (On the storybook preview generated on the PR checks)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
