### PR TITLE
fix(font-preload): change url to the right one

### DIFF
--- a/packages/admin-ui-react/src/createSystem.tsx
+++ b/packages/admin-ui-react/src/createSystem.tsx
@@ -53,7 +53,7 @@ export function createSystem(spec: CreateSystemOptions): CreateSystemReturn {
             <Helmet>
               <link
                 rel="preload"
-                href="https://io.vtex.com.br/fonts/vtex-trust/VTEXTrust-Variable.woff2"
+                href="https://io.vtex.com.br/fonts/vtex-trust/VTEXTrust-VF.woff2"
                 as="font"
                 type="font/woff2"
                 crossOrigin="anonymous"


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
We were downloading VTEX Trust font from a URL in our theme and making the preload of a different one, and in this way we were downloading two fonts every time.


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Every time a page using Admin UI is rendered it downloads the VTEX Trust font two times and this can cause performance issues, as shown in the image below where I ran the lighthouse in VTEX admin

![Captura de Tela 2022-03-11 às 16 39 51](https://user-images.githubusercontent.com/20579226/157946123-974406e2-211b-473b-9a6d-890799f3d38f.png)

#### How should this be manually tested?
<!--- Usually `yarn and yarn test`, but feel encouraged to add a more descriptive explanation. -->

You can check that now we are preloading the [same font used in our theme](https://github.com/vtex/admin-ui/blob/main/packages/admin-ui-core/src/values/typography.ts#L8)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
