### PR TITLE
[AU-117] Calls onClose on state.hide

### DIFF
--- a/packages/admin-ui/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/admin-ui/src/components/Modal/__tests__/Modal.test.tsx
@@ -9,6 +9,7 @@ import {
   ModalFooter,
   useModalState,
 } from '../index'
+import { fireEvent, screen } from '@testing-library/react'
 
 global.MutationObserver = window.MutationObserver
 
@@ -76,5 +77,106 @@ describe('Modal', () => {
     const results = await axe(container)
 
     expect(results).toHaveNoViolations()
+  })
+
+  it('should call onClose when calls state.hide', () => {
+    const onCloseMocked = jest.fn()
+
+    const Example = () => {
+      const state = useModalState({ visible: true })
+
+      return (
+        <>
+          <Modal state={state} onClose={onCloseMocked} aria-label="modal">
+            <ModalHeader title="Header" />
+            <ModalContent>
+              <div>modal content</div>
+            </ModalContent>
+            <ModalFooter>
+              <button>footer button</button>
+            </ModalFooter>
+          </Modal>
+          <button onClick={state.hide}>Hide</button>
+        </>
+      )
+    }
+
+    render(<Example />)
+
+    fireEvent.click(screen.getByText('Hide'))
+    fireEvent.click(screen.getByText('Hide'))
+
+    expect(onCloseMocked).toBeCalledTimes(1)
+  })
+
+  it('should call onClose with hideOnEsc', () => {
+    const onCloseMocked = jest.fn()
+
+    const Example = () => {
+      const state = useModalState({ visible: true })
+
+      return (
+        <>
+          <Modal
+            state={state}
+            onClose={onCloseMocked}
+            aria-label="modal"
+            hideOnEsc
+          >
+            <ModalHeader title="Header" />
+            <ModalContent>
+              <div>modal content</div>
+            </ModalContent>
+            <ModalFooter>
+              <button>footer button</button>
+            </ModalFooter>
+          </Modal>
+        </>
+      )
+    }
+
+    render(<Example />)
+
+    fireEvent.keyDown(screen.getByLabelText('modal'), { key: 'Escape' })
+    fireEvent.keyDown(screen.getByLabelText('modal'), { key: 'Escape' })
+
+    expect(onCloseMocked).toBeCalledTimes(1)
+  })
+
+  it('should call onClose with hideOnClickOutside', () => {
+    const onCloseMocked = jest.fn()
+
+    const Example = () => {
+      const state = useModalState({ visible: true })
+
+      return (
+        <>
+          <Modal
+            state={state}
+            onClose={onCloseMocked}
+            aria-label="modal"
+            hideOnClickOutside
+          >
+            <ModalHeader title="Header" />
+            <ModalContent>
+              <div>modal content</div>
+            </ModalContent>
+            <ModalFooter>
+              <button>footer button</button>
+            </ModalFooter>
+          </Modal>
+        </>
+      )
+    }
+
+    const { baseElement } = render(<Example />)
+
+    fireEvent.mouseDown(baseElement)
+    fireEvent.click(baseElement)
+
+    fireEvent.mouseDown(baseElement)
+    fireEvent.click(baseElement)
+
+    expect(onCloseMocked).toBeCalledTimes(1)
   })
 })

--- a/packages/admin-ui/src/components/Modal/components/Modal.tsx
+++ b/packages/admin-ui/src/components/Modal/components/Modal.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import React, { useCallback } from 'react'
+import React from 'react'
 import type { StyleProp } from '@vtex/admin-ui-core'
 import type { DialogOptions } from 'reakit/Dialog'
 import { Dialog, DialogBackdrop } from 'reakit/Dialog'
@@ -10,6 +10,7 @@ import { ModalProvider } from './ModalContext'
 import type { ModalSize } from '../types'
 import { useComponentsExistence } from '../util'
 import type { SystemComponent } from '../../../types'
+import { useModalStateListener } from '../state.internals'
 
 const widths = {
   mobile: 'calc(100% - 16px)',
@@ -53,10 +54,7 @@ export function Modal(props: ModalProps) {
     ...baseProps
   } = props
 
-  const handleClose = useCallback(() => {
-    state.hide()
-    onClose()
-  }, [onClose, state])
+  useModalStateListener(state, 'close', onClose)
 
   const { hasHeader, hasFooter, scrollStyle } = useComponentsExistence(children)
 
@@ -123,7 +121,6 @@ export function Modal(props: ModalProps) {
             state,
             hasHeader,
             hasFooter,
-            handleClose,
             size,
             omitCloseButton,
           }}

--- a/packages/admin-ui/src/components/Modal/components/ModalButton.tsx
+++ b/packages/admin-ui/src/components/Modal/components/ModalButton.tsx
@@ -32,7 +32,7 @@ export const ModalButton = forwardRef(function ModalButton(
     ...buttonProps
   } = props
 
-  const { handleClose } = useModalContext()
+  const { state } = useModalContext()
 
   const handleClick = (
     event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>
@@ -40,7 +40,7 @@ export const ModalButton = forwardRef(function ModalButton(
     onClick(event)
 
     if (closeModalOnClick) {
-      handleClose()
+      state.hide()
     }
   }
 

--- a/packages/admin-ui/src/components/Modal/components/ModalContext.tsx
+++ b/packages/admin-ui/src/components/Modal/components/ModalContext.tsx
@@ -6,7 +6,6 @@ import type { ModalSize } from '../types'
 
 const ModalContext = React.createContext<{
   state: DialogStateReturn
-  handleClose: () => void
   omitCloseButton?: boolean
   hasHeader: boolean
   hasFooter: boolean

--- a/packages/admin-ui/src/components/Modal/state.internals.tsx
+++ b/packages/admin-ui/src/components/Modal/state.internals.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { useCallbackRef } from '@vtex/admin-ui-hooks'
+import type { ModalStateReturn } from './state'
+
+export const kListeners = Symbol('useModalState#listeners')
+
+export type ModalStateListeners = {
+  close: Set<() => void>
+}
+
+export type ModalStateEventNames = keyof ModalStateListeners
+
+export const useModalStateListener = (
+  state: ModalStateReturn,
+  eventName: ModalStateEventNames,
+  callback: () => void
+) => {
+  const callbackRef = useCallbackRef(callback)
+  const listeners = state[kListeners][eventName]
+
+  useEffect(() => {
+    listeners.add(callbackRef)
+
+    return () => {
+      listeners.delete(callbackRef)
+    }
+  }, [])
+}

--- a/packages/admin-ui/src/components/Modal/state.tsx
+++ b/packages/admin-ui/src/components/Modal/state.tsx
@@ -1,22 +1,49 @@
-import {
-  useDialogState,
-  DialogStateReturn,
-  DialogInitialState,
-} from 'reakit/Dialog'
+import { useMemo } from 'react'
+import type { DialogInitialState, DialogStateReturn } from 'reakit/Dialog'
+import { useDialogState } from 'reakit/Dialog'
+import type { ModalStateListeners } from './state.internals'
+import { kListeners } from './state.internals'
 
-function useModalState(
-  initialState?: Omit<DialogInitialState, 'animated'> | undefined
-) {
+export type ModalInitialState = Omit<DialogInitialState, 'animated'>
+
+export type ModalStateReturn = DialogStateReturn & {
+  [kListeners]: ModalStateListeners
+}
+
+function useModalState(initialState?: ModalInitialState | undefined) {
   const dialogState = useDialogState({
     animated: true,
     ...initialState,
   })
 
-  return dialogState
+  const listeners: ModalStateListeners = useMemo(
+    () => ({
+      close: new Set(),
+    }),
+    []
+  )
+
+  const state: ModalStateReturn = useMemo(() => {
+    const hide = () => {
+      const { visible } = dialogState
+
+      dialogState.hide()
+
+      if (visible) {
+        listeners.close.forEach((callback) => {
+          callback()
+        })
+      }
+    }
+
+    return {
+      ...dialogState,
+      [kListeners]: listeners,
+      hide,
+    }
+  }, [dialogState])
+
+  return state
 }
 
-export {
-  useModalState,
-  DialogStateReturn as ModalStateReturn,
-  DialogInitialState as ModalInitialState,
-}
+export { useModalState }


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Associate the `Modal#onClose` with the `modalState.hide`, so when someone calls it, it will call the `onClose` passed to the `Modal`.

#### What problem is this solving?
- Enable people to use `modal.hide` but don't forget to call the `onClose` event when the modal closes.

#### How should this be manually tested?

- Just run `yarn test`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://camo.githubusercontent.com/116ab54887554b64eca7454907fbf20ed122cee5204013a9a75c27fa0891e354/68747470733a2f2f6d65646961342e67697068792e636f6d2f6d656469612f31314b7a4f657431456c42447a322f67697068792e6769663f6369643d65636630356534373139313465613032326761346a743179366a6a32736b76393931616d69637a303135307361726330267269643d67697068792e6769662663743d67)
