### PR TITLE
NAD-1035 - Toast: expose `csx` props

### DIFF
--- a/packages/admin-ui/src/components/Toast/__stories__/Toast.stories.tsx
+++ b/packages/admin-ui/src/components/Toast/__stories__/Toast.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta } from '@storybook/react'
 import { ToastProvider, useToast } from '../index'
 import { Button } from '../../../button'
 import { Set } from '../../Set'
+import { Text } from '../../Text'
 
 export default {
   title: 'admin-ui/Toast',
@@ -20,7 +21,12 @@ const ToastButton = () => {
           showToast({
             message: 'Type here a longer message but not much longer than that',
             dismissible: true,
-            action: { label: 'Action', onClick: () => {} },
+            action: {
+              label: 'Action',
+              onClick: () => {
+                alert('Some action!')
+              },
+            },
           })
         }}
       >
@@ -32,11 +38,16 @@ const ToastButton = () => {
             message: 'This is a Toast!',
             dismissible: true,
             tone: 'positive',
-            action: { label: 'Action', onClick: () => {} },
+            action: {
+              label: 'Action',
+              onClick: () => {
+                alert('Some action!')
+              },
+            },
           })
         }}
       >
-        positive
+        Positive
       </Button>
       <Button
         onClick={() => {
@@ -44,11 +55,16 @@ const ToastButton = () => {
             message: 'This is a Toast!',
             dismissible: true,
             tone: 'critical',
-            action: { label: 'Action', onClick: () => {} },
+            action: {
+              label: 'Action',
+              onClick: () => {
+                alert('Some action!')
+              },
+            },
           })
         }}
       >
-        critical
+        Critical
       </Button>
       <Button
         onClick={() => {
@@ -56,11 +72,44 @@ const ToastButton = () => {
             message: 'This is a Toast!',
             dismissible: true,
             tone: 'warning',
-            action: { label: 'Action', onClick: () => {} },
+            action: {
+              label: 'Action',
+              onClick: () => {
+                alert('Some action!')
+              },
+            },
           })
         }}
       >
         Warning
+      </Button>
+      <Button
+        onClick={() => {
+          showToast({
+            message: (
+              <>
+                <Text variant="pageTitle">Hi there!</Text>
+                <br />
+                <Text>
+                  This is a custom Toast with a higher than average height and a
+                  button-like behavior.
+                </Text>
+              </>
+            ),
+            dismissible: true,
+            tone: 'positive',
+            csx: {
+              maxHeight: 'auto',
+              ':hover': {
+                background: '#C0E1D5',
+                cursor: 'pointer',
+              },
+            },
+            onClick: () => alert('Hello world!'),
+          })
+        }}
+      >
+        Custom
       </Button>
     </Set>
   )

--- a/packages/admin-ui/src/components/Toast/components/Toast.tsx
+++ b/packages/admin-ui/src/components/Toast/components/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
+import type { MouseEvent } from 'react'
 import {
   IconX,
   IconXOctagon,
@@ -33,9 +34,11 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       onClear,
       dismissible,
       action,
+      csx = {},
       shouldRemove,
       tone = 'info',
       duration = 10000,
+      ...divProps
     } = props
 
     const remove = useCallback(
@@ -62,6 +65,9 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
         onMouseEnter={stopTimeout}
         onMouseLeave={startTimeout}
         tone={tone}
+        csx={csx}
+        {...divProps}
+        onClick={divProps?.onClick}
       >
         <tag.div
           csx={{
@@ -79,9 +85,10 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
               <Button
                 variant="neutralTertiary"
                 key={action.label}
-                onClick={() => {
+                onClick={(event: MouseEvent<HTMLButtonElement>) => {
                   remove()
                   action.onClick()
+                  event.stopPropagation()
                 }}
                 csx={{ color: '$action.main.tertiary' }}
               >
@@ -93,7 +100,10 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
                 variant="neutralTertiary"
                 icon={<IconX />}
                 aria-label="Close toast"
-                onClick={remove}
+                onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                  remove()
+                  event.stopPropagation()
+                }}
               />
             )}
           </tag.div>

--- a/packages/admin-ui/src/components/Toast/components/Toast.tsx
+++ b/packages/admin-ui/src/components/Toast/components/Toast.tsx
@@ -67,7 +67,6 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
         tone={tone}
         csx={csx}
         {...divProps}
-        onClick={divProps?.onClick}
       >
         <tag.div
           csx={{

--- a/packages/admin-ui/src/components/Toast/types.ts
+++ b/packages/admin-ui/src/components/Toast/types.ts
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react'
+import type { HTMLAttributes, ReactNode } from 'react'
+import type { StyleProp } from '@vtex/admin-ui-core'
 
 export interface ToastAction {
   /**
@@ -26,7 +27,7 @@ export interface InternalToast extends Toast {
   shouldRemove: boolean
 }
 
-export interface Toast {
+export interface Toast extends HTMLAttributes<HTMLDivElement> {
   /**
    * Toast's key
    */
@@ -54,4 +55,9 @@ export interface Toast {
    * @default 10000
    */
   duration?: number
+  /**
+   * `csx` properties
+   * @default {}
+   */
+  csx?: StyleProp
 }


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?

To expose the Toast's `csx` props and allow it to be customized.

[These changes are needed to address the Admin Notifications project needs, per Figma specs.](https://www.figma.com/file/zOfC9TCYPQnCXlQ1wKDwmI/Notification-XP-Specs?node-id=1%3A4603)

#### What problem is this solving?

Currently, Toast's styles are not overridable. This PR allows them to be customizable.

Also, it inherits the `HTMLDivElement` interface, making it possible to alter the Toast's behavior.

#### How should this be manually tested?

[Take a look at the `Custom` Toast from the Storybook preview.](https://admin-ui-toast-csx.surge.sh/?path=/story/admin-ui-toast--playground)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly