### PR TITLE
NAD-1080 docs(alert): add design reference tab

### DIFF
--- a/packages/admin-ui-docs/docs/guidelines/components/alert.mdx
+++ b/packages/admin-ui-docs/docs/guidelines/components/alert.mdx
@@ -6,7 +6,6 @@ hide_table_of_contents: true
 
 import { Page, Panel } from '@site/src/components/Page'
 
-
 export const tabToc = {
   overview: toc.filter((item) =>
     [
@@ -21,6 +20,7 @@ export const tabToc = {
     ].includes(item.value)
   ),
   codeReference: toc.filter((item) => ['Usage', 'Props'].includes(item.value)),
+  designReference: toc.filter((item) => ['Documentation'].includes(item.value)),
 }
 
 <Page toc={tabToc} hasTabs>
@@ -175,6 +175,58 @@ function Example() {
 
   </Panel>
   <Panel id="designReference">
+
+## Documentation
+
+Alerts are notifications of mild to high priority. They may inform the user about events they should know, or explain a problem and point out a solution. They may be triggered by a user action or not, and may refer to actions performed by other users, accounts, on different moments in time.
+
+**Anatomy**
+
+Follow the anatomy described below. Be sure to include:
+
+1. Alert message
+2. Action button
+3. Dismiss button
+4. Icon
+5. Box
+
+**Do’s**
+
+1. They follow the page's grid, adapting to full 100% width, or centralized over a smaller container, for instance.
+2. They don't overlap with sidebars. They are contextualized within containers.
+3. They can’t be placed over the page's header. They are contextualized within containers.
+4. Provide visible feedback to user actions by using alerts.
+5. In high priority alerts, completing the task is the main focus. Our role is to assure that the user will solve their problem, by providing enough information to do it, through a clear message and action button.
+6. Should be expressed in plain language (no codes), precisely indicate the problem, and constructively suggest a solution.
+7. The user needs to know exactly what happened. Even if we work to assure full SLA, things can fail. There are even some scenarios that are beyond our direct control. Because of this, it’s extremely important that our users understand what is blocking them to finish their tasks.
+8. Errors must be actionable. As users understand what is happening, we need to give them proper following actions.
+9. We should always calm the user, not cause more stress.
+10. Alerts can be stacked.
+
+**Alert types**
+
+**Information**
+
+Use this to give instant feedback about the tasks a user just performed. Its main objective is to ensure task confirmation, or notify about further actions.
+Do not represent alarm or danger, but provide visibility about the system’s operations. Ex. You have 4 new releases to review.
+
+**Warning**
+
+Use this when user needs to know about some important info before taking any decision. Adds a higher note of urgency over situations that may cause problems to the user’s store, but aren’t yet causing trouble.
+Ex. Sorry, this account is inactive. Please check your store’s billing for more information.
+
+**Danger**
+
+Use this when something went wrong after performing an action. Situation should be checked with urgency, since it’s already causing problems to the user’s store, and require manual resolution. This alert isn’t dismissable, and should stay on until the problem is fixed.
+Ex. Sorry, something went wrong. Please, try again, or refresh your page.
+
+**Success**
+
+Use this when the user's action had a successful outcome. You can consider using toasts for this situation.
+Ex. Order successfully placed.
+
+👉 For UX Writing guidelines, access https://uxwriting.vtex.com
+
   </Panel>
   <Panel id="codeReference">
 

--- a/packages/admin-ui-docs/docs/guidelines/components/alert.mdx
+++ b/packages/admin-ui-docs/docs/guidelines/components/alert.mdx
@@ -176,21 +176,7 @@ function Example() {
   </Panel>
   <Panel id="designReference">
 
-## Documentation
-
-Alerts are notifications of mild to high priority. They may inform the user about events they should know, or explain a problem and point out a solution. They may be triggered by a user action or not, and may refer to actions performed by other users, accounts, on different moments in time.
-
-**Anatomy**
-
-Follow the anatomy described below. Be sure to include:
-
-1. Alert message
-2. Action button
-3. Dismiss button
-4. Icon
-5. Box
-
-**Do’s**
+## Do’s
 
 1. They follow the page's grid, adapting to full 100% width, or centralized over a smaller container, for instance.
 2. They don't overlap with sidebars. They are contextualized within containers.
@@ -203,24 +189,24 @@ Follow the anatomy described below. Be sure to include:
 9. We should always calm the user, not cause more stress.
 10. Alerts can be stacked.
 
-**Alert types**
+## Alert types
 
-**Information**
+### Information
 
 Use this to give instant feedback about the tasks a user just performed. Its main objective is to ensure task confirmation, or notify about further actions.
 Do not represent alarm or danger, but provide visibility about the system’s operations. Ex. You have 4 new releases to review.
 
-**Warning**
+### Warning
 
 Use this when user needs to know about some important info before taking any decision. Adds a higher note of urgency over situations that may cause problems to the user’s store, but aren’t yet causing trouble.
 Ex. Sorry, this account is inactive. Please check your store’s billing for more information.
 
-**Danger**
+### Danger
 
 Use this when something went wrong after performing an action. Situation should be checked with urgency, since it’s already causing problems to the user’s store, and require manual resolution. This alert isn’t dismissable, and should stay on until the problem is fixed.
 Ex. Sorry, something went wrong. Please, try again, or refresh your page.
 
-**Success**
+### Success
 
 Use this when the user's action had a successful outcome. You can consider using toasts for this situation.
 Ex. Order successfully placed.

--- a/packages/admin-ui-docs/src/components/Page/index.tsx
+++ b/packages/admin-ui-docs/src/components/Page/index.tsx
@@ -32,8 +32,8 @@ const getTabColor = (selectedId: string, tabId: string) => {
 
 const tabName = {
   overview: 'Overview',
-  designReference: 'Design Reference',
-  codeReference: 'Code Reference',
+  designReference: 'Design',
+  codeReference: 'Code',
 }
 
 export function Page(props: PageProps) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add "Design Reference" tab for the Alert component on the doc site.

#### What problem is this solving?
Lack of content.

#### How should this be manually tested?
`yarn docs` locally.

#### Screenshots or example usage
![Screen Shot 2022-04-12 at 09 40 03](https://user-images.githubusercontent.com/2573602/162964383-6c136b0f-5e96-4c04-8747-8d982f79e138.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
