### PR TITLE
feat(radio): add Radio and RadioGroup codemod

### DIFF
--- a/packages/admin-ui-codemod/bin/cli.js
+++ b/packages/admin-ui-codemod/bin/cli.js
@@ -101,6 +101,10 @@ const TRANSFORMER_INQUIRER_CHOICES = [
     name: 'set-to-stack: Migrate Set to Stack',
     value: 'set-to-stack',
   },
+  {
+    name: 'radio-review: Update Radio & RadioGroup props to the latest specs (0.126.0+)',
+    value: 'radio-review',
+  },
 ]
 
 // tsx or jsx

--- a/packages/admin-ui-codemod/src/__tests__/radio-review.test.js
+++ b/packages/admin-ui-codemod/src/__tests__/radio-review.test.js
@@ -1,0 +1,118 @@
+const defineInlineTest = require('jscodeshift/dist/testUtils').defineInlineTest
+const radioTransform = require('../radio-review')
+
+describe('Preserve Radio', () => {
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<Radio />',
+    '<Radio />',
+    'preserve Radio self closing'
+  )
+
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<Radio disabled checked />',
+    '<Radio disabled checked />',
+    'preserve props'
+  )
+})
+
+describe('Radio sizes', () => {
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<Radio size="regular" />',
+    '<Radio />',
+    'remove size property and its value'
+  )
+
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<Radio size="small" />',
+    '<Radio />',
+    'remove size property and its value'
+  )
+})
+
+describe('Radio states', () => {
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<Radio state={radioState} />',
+    '<Radio />',
+    'remove state property and its value'
+  )
+
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<Radio state={state} />',
+    '<Radio />',
+    'remove state property and its value'
+  )
+})
+
+describe('Preserve RadioGroup', () => {
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<RadioGroup />',
+    '<RadioGroup />',
+    'preserve RadioGroup self closing'
+  )
+
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<RadioGroup><Radio /></RadioGroup>',
+    '<RadioGroup><Radio /></RadioGroup>',
+    'preserve RadioGroups w/ children'
+  )
+
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<RadioGroup label="Group Label" state={state} />',
+    '<RadioGroup label="Group Label" state={state} />',
+    'preserve props'
+  )
+})
+
+describe('RadioGroup sizes', () => {
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<RadioGroup size="regular" />',
+    '<RadioGroup />',
+    'remove size property and its value'
+  )
+
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<RadioGroup size="small" />',
+    '<RadioGroup />',
+    'remove size property and its value'
+  )
+})
+
+describe('RadioGroup direction', () => {
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<RadioGroup orientation="vertical" />',
+    '<RadioGroup direction="column" />',
+    'replace orientation property by direction'
+  )
+
+  defineInlineTest(
+    radioTransform,
+    {},
+    '<RadioGroup orientation="horizontal" />',
+    '<RadioGroup direction="row" />',
+    'replace orientation property by direction'
+  )
+})

--- a/packages/admin-ui-codemod/src/radio-review.js
+++ b/packages/admin-ui-codemod/src/radio-review.js
@@ -1,0 +1,55 @@
+function remove(source, j, componentName, props) {
+  return j(source)
+    .find(j.JSXOpeningElement, { name: { name: componentName } })
+    .forEach((p) => {
+      const { name, attributes, selfClosing } = p.value
+
+      const newAttributes = attributes.filter((attribute) => {
+        return !props.includes(attribute.name.name)
+      })
+
+      j(p).replaceWith(j.jsxOpeningElement(name, newAttributes, selfClosing))
+    })
+    .toSource()
+}
+
+function replace(source, j, componentName) {
+  return j(source)
+    .find(j.JSXOpeningElement, { name: { name: componentName } })
+    .forEach((p) => {
+      const { name, attributes, selfClosing } = p.value
+
+      const newAttributes = attributes.map((attribute) => {
+        if (attribute.name.name === 'orientation') {
+          return j.jsxAttribute(
+            j.jsxIdentifier('direction'),
+            j.literal(transformDirection(attribute.value.value))
+          )
+        }
+
+        return attribute
+      })
+
+      j(p).replaceWith(j.jsxOpeningElement(name, newAttributes, selfClosing))
+    })
+    .toSource()
+}
+
+function transformDirection(value) {
+  if (!value) return 'column'
+
+  return {
+    vertical: 'column',
+    horizontal: 'row',
+  }[value]
+}
+
+module.exports = function (file, { jscodeshift: j }) {
+  let { source } = file
+
+  source = replace(source, j, 'RadioGroup')
+  source = remove(source, j, 'Radio', ['state', 'size'])
+  source = remove(source, j, 'RadioGroup', ['size'])
+
+  return source
+}


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
The Radio review introduces some breaking changes in the Radio and RadioGroup components. This PR adds a codemod to help admin-ui users to migrate to the new version.

## Codemod

**Remove size property**

```jsx
// before
<Radio size="small" />

// after
<Radio />

// before
<RadioGroup size="small" />

// after
<RadioGroup />
```

**Remove Radio state property**

```jsx
// before
<Radio state={state} />

// after
<Radio />
```

**Rename orientation to direction**

```jsx
// before
<RadioGroup orientation="vertical" />

// after
<RadioGroup direction="column" />

// before
<RadioGroup orientation="horizontal" />

// after
<RadioGroup direction="row" />
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
