### PR TITLE
feat(admin-ui-form): create library w/ form & watch features

### DIFF
--- a/packages/admin-ui-form/LICENSE
+++ b/packages/admin-ui-form/LICENSE
@@ -1,0 +1,22 @@
+
+MIT License
+
+Copyright 2022 VTEX
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/admin-ui-form/package.json
+++ b/packages/admin-ui-form/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@vtex/admin-ui-form",
+  "description": "Admin UI form library",
+  "license": "MIT",
+  "version": "0.0.0",
+  "main": "dist/vtex-admin-ui-form.cjs.js",
+  "module": "dist/vtex-admin-ui-form.esm.js",
+  "typings": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "engines": {
+    "node": ">=10"
+  },
+  "repository": {
+    "directory": "packages/admin-ui-form",
+    "type": "git",
+    "url": "git+https://github.com/vtex/admin-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vtex/admin-ui/issues"
+  },
+  "peerDependencies": {
+    "react": ">=16.8",
+    "react-dom": ">=16.8",
+    "@vtex/admin-ui": "0.x"
+  },
+  "dependencies": {
+    "react-hook-form": "7.31.1",
+    "tiny-invariant": "1.2.0"
+  }
+}

--- a/packages/admin-ui-form/src/form/form.state.ts
+++ b/packages/admin-ui-form/src/form/form.state.ts
@@ -1,0 +1,5 @@
+import { useForm as useFormState } from 'react-hook-form'
+
+export { useFormState }
+
+export type FormState = ReturnType<typeof useFormState>

--- a/packages/admin-ui-form/src/form/form.ts
+++ b/packages/admin-ui-form/src/form/form.ts
@@ -1,0 +1,22 @@
+import type { AnyObject } from '@vtex/admin-ui'
+import { createComponent, useElement } from '@vtex/admin-ui'
+
+import type { FormState } from './form.state'
+
+export const Form = createComponent<'form', FormProps>((props) => {
+  const { state, onSubmit, ...formProps } = props
+
+  const { handleSubmit } = state
+
+  return useElement('form', {
+    onSubmit: handleSubmit(onSubmit),
+    ...formProps,
+  })
+})
+
+Form.displayName = 'Form'
+
+export interface FormProps {
+  state: FormState
+  onSubmit: (data: AnyObject) => void
+}

--- a/packages/admin-ui-form/src/form/index.ts
+++ b/packages/admin-ui-form/src/form/index.ts
@@ -1,0 +1,2 @@
+export * from './form'
+export * from './form.state'

--- a/packages/admin-ui-form/src/form/stories/form.stories.tsx
+++ b/packages/admin-ui-form/src/form/stories/form.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import type { Meta } from '@storybook/react'
+import { Box } from '@vtex/admin-ui'
+
+import { Form, useFormState } from '../index'
+
+export default {
+  title: 'admin-ui-form/form',
+} as Meta
+
+export const RegisterFields = () => {
+  const form = useFormState()
+
+  return (
+    <Box>
+      <Form onSubmit={(data) => console.log(data)} state={form}>
+        <input placeholder="First Name" {...form.register('firstName')} />
+        <input placeholder="Age" type="number" {...form.register('age')} />
+        <input placeholder="Favorite Food" {...form.register('favFood')} />
+        <input type="submit" value="Submit" />
+      </Form>
+    </Box>
+  )
+}
+
+export const validation = () => {
+  const form = useFormState()
+
+  return (
+    <Box>
+      <Form onSubmit={(data) => console.log(data)} state={form}>
+        <Box>
+          <input
+            placeholder="First Name"
+            {...form.register('firstName', { required: true, maxLength: 20 })}
+          />
+          <Box>
+            {form.formState.errors.firstName?.type === 'required' &&
+              'First name is required'}
+            {form.formState.errors.firstName?.type === 'maxLength' &&
+              'The max length is 20'}
+          </Box>
+        </Box>
+
+        <Box>
+          <input
+            placeholder="Age"
+            type="number"
+            {...form.register('age', { min: 18, max: 99 })}
+          />
+          <Box>
+            {form.formState.errors.age?.type === 'min' && 'The min age is 18'}
+            {form.formState.errors.age?.type === 'max' && 'The max age is 99'}
+          </Box>
+        </Box>
+
+        <Box>
+          <input
+            placeholder="Favorite Food"
+            {...form.register('favFood', { pattern: /^[A-Za-z]+$/i })}
+          />
+          <Box>
+            {form.formState.errors.favFood?.type === 'pattern' &&
+              'Only strings are accepted'}
+          </Box>
+        </Box>
+
+        <input type="submit" value="Submit" />
+      </Form>
+    </Box>
+  )
+}

--- a/packages/admin-ui-form/src/index.ts
+++ b/packages/admin-ui-form/src/index.ts
@@ -1,0 +1,2 @@
+export * from './form'
+export * from './watch'

--- a/packages/admin-ui-form/src/watch/index.ts
+++ b/packages/admin-ui-form/src/watch/index.ts
@@ -1,0 +1,2 @@
+export * from './use-watch'
+export * from './watch'

--- a/packages/admin-ui-form/src/watch/stories/watch.stories.tsx
+++ b/packages/admin-ui-form/src/watch/stories/watch.stories.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import type { Meta } from '@storybook/react'
+import { Box } from '@vtex/admin-ui'
+
+import { useFormState, Form } from '../../form'
+import { useWatch, Watch } from '../index'
+
+export default {
+  title: 'admin-ui-form/watch',
+} as Meta
+
+export const UseWatch = () => {
+  const form = useFormState()
+
+  const firstName = useWatch({
+    form,
+    name: 'firstName',
+  })
+
+  const age = useWatch({
+    form,
+    name: 'age',
+  })
+
+  const favFood = useWatch({
+    form,
+    name: 'favFood',
+  })
+
+  return (
+    <Box>
+      <Form onSubmit={(data) => console.log(data)} state={form}>
+        <input placeholder="First Name" {...form.register('firstName')} />
+        <input placeholder="Age" type="number" {...form.register('age')} />
+        <input placeholder="Favorite Food" {...form.register('favFood')} />
+        <input type="submit" value="Submit" />
+      </Form>
+      <Box>
+        <Box as="p">firstName: {firstName}</Box>
+        <Box as="p">age: {age}</Box>
+        <Box as="p">favFood: {favFood}</Box>
+      </Box>
+    </Box>
+  )
+}
+
+export const WatchComponent = () => {
+  const form = useFormState()
+
+  return (
+    <Box>
+      <Form onSubmit={(data) => console.log(data)} state={form}>
+        <input placeholder="First Name" {...form.register('firstName')} />
+        <input placeholder="Age" type="number" {...form.register('age')} />
+        <input placeholder="Favorite Food" {...form.register('favFood')} />
+        <input type="submit" value="Submit" />
+      </Form>
+      <Box>
+        <Box as="p">
+          firstName:
+          <Watch name="firstName" form={form} />
+        </Box>
+        <Box as="p">
+          age:
+          <Watch name="age" form={form} />
+        </Box>
+        <Box as="p">
+          favFood:
+          <Watch name="favFood" form={form}>
+            {(value) => <>{value}</>}
+          </Watch>
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/packages/admin-ui-form/src/watch/use-watch.ts
+++ b/packages/admin-ui-form/src/watch/use-watch.ts
@@ -1,0 +1,43 @@
+import { useWatch as useWatchBase } from 'react-hook-form'
+import type { FormState } from '../form'
+
+/**
+ * React Hook for subscribe to input changes
+ * @example
+ * const form = useFormState()
+ * const subscribedValue = useWatch({
+ *   form,
+ *   name: "fieldName"
+ * })
+ */
+export function useWatch(props: UseWatchProps) {
+  const { form, name, defaultValue, disabled } = props
+
+  return useWatchBase({
+    control: form.control,
+    name,
+    defaultValue,
+    disabled,
+  })
+}
+
+export interface UseWatchProps {
+  /** Target form */
+  form: FormState
+  /**  Name of the field */
+  name: string
+  /** Default value for useWatch to return before the initial render */
+  defaultValue?: unknown
+  /**
+   * Option to disable the subscription
+   * @default false
+   * */
+  disabled?: boolean
+  /**
+   * Enables an exact match for input name subscriptions
+   * @default false
+   */
+  exact?: boolean
+}
+
+export type WatchState = ReturnType<typeof useWatch>

--- a/packages/admin-ui-form/src/watch/watch.tsx
+++ b/packages/admin-ui-form/src/watch/watch.tsx
@@ -1,0 +1,22 @@
+import React, { Fragment } from 'react'
+import type { ReactNode } from 'react'
+import type { UseWatchProps, WatchState } from './use-watch'
+import { useWatch } from './use-watch'
+
+/**
+ * React Component for subscribe to input changes
+ * @example
+ * const form = useFormState()
+ *
+ * <Watch name="fieldName" form={form} />
+ */
+export function Watch(props: WatchProps) {
+  const { children, ...hookProps } = props
+  const watch = useWatch(hookProps)
+
+  return <Fragment>{children ? children(watch) : watch}</Fragment>
+}
+
+export interface WatchProps extends UseWatchProps {
+  children?: (props: WatchState) => ReactNode
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17539,6 +17539,11 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-hook-form@7.31.1:
+  version "7.31.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.31.1.tgz#16c357dd366bc226172e6acbb5a1672873bbfb28"
+  integrity sha512-QjtjZ8r8KtEBWWpcXLyQordCraTFxILtyQpaz5KLLxN2YzcC+FZ9LLtOnNGuOnzZo9gCoB+viK3ZHV9Mb2htmQ==
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -20012,7 +20017,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-invariant@^1.0.2, tiny-invariant@^1.0.6, tiny-invariant@^1.1.0, tiny-invariant@^1.2.0:
+tiny-invariant@1.2.0, tiny-invariant@^1.0.2, tiny-invariant@^1.0.6, tiny-invariant@^1.1.0, tiny-invariant@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==


### PR DESCRIPTION
#### What is the purpose of this pull request?
Bootstrap of our upcoming form state handling library. Included features:
- useFormState: to keep the state of the form
- Form: the submission element
- useWatch: to subscribe to input changes w/isolate renders
- Watch: render-props version of useWatch

#### What problem is this solving?
- We must have a consistent, performant, and DX-through form state library.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
