### PR TITLE
fix(text-input): a11y, spaces, and next terminology

### DIFF
--- a/packages/admin-ui/src/checkbox/__snapshots__/checkbox.test.tsx.snap
+++ b/packages/admin-ui/src/checkbox/__snapshots__/checkbox.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Checkbox should match snapshot 1`] = `
 }
 
 .emotion-7 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-6 {
@@ -268,6 +268,7 @@ exports[`Checkbox should match snapshot 1`] = `
           </span>
           <span
             class="emotion-3"
+            role="alert"
           >
             Error text
           </span>
@@ -299,7 +300,7 @@ exports[`Checkbox should match snapshot to checkbox group 1`] = `
 }
 
 .emotion-7 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-6 {
@@ -764,6 +765,7 @@ exports[`Checkbox should match snapshot to checkbox group 1`] = `
               >
                 <span
                   class="emotion-15"
+                  role="alert"
                 >
                   Error Text
                 </span>

--- a/packages/admin-ui/src/filters/__tests__/__snapshots__/filter-multiple.test.tsx.snap
+++ b/packages/admin-ui/src/filters/__tests__/__snapshots__/filter-multiple.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`Multiselect filter tests should match snapshot 1`] = `
 }
 
 .emotion-4 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-3 {

--- a/packages/admin-ui/src/form-control/__snapshots__/form-control.test.tsx.snap
+++ b/packages/admin-ui/src/form-control/__snapshots__/form-control.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`FormControl should match snapshot 1`] = `
 }
 
 .emotion-5 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-0 {
@@ -310,6 +310,7 @@ exports[`FormControl should match snapshot 1`] = `
       </span>
       <span
         class="emotion-12"
+        role="alert"
       >
         Error Text
       </span>

--- a/packages/admin-ui/src/form-control/form-control-message.tsx
+++ b/packages/admin-ui/src/form-control/form-control-message.tsx
@@ -22,7 +22,7 @@ export function FormControlMessage(props: FormControlMessageProps) {
         </Text>
       ) : null}
       {hasError ? (
-        <Text variant="detail" tone="critical">
+        <Text variant="detail" tone="critical" role="alert">
           {errorText}
         </Text>
       ) : null}

--- a/packages/admin-ui/src/form-control/form-control.tsx
+++ b/packages/admin-ui/src/form-control/form-control.tsx
@@ -10,7 +10,7 @@ export function FormControl(props: FormGroupOptions) {
 
   return (
     <FormControlProvider {...remainingProps}>
-      <Stack space="$l">{children}</Stack>
+      <Stack space="$m">{children}</Stack>
     </FormControlProvider>
   )
 }

--- a/packages/admin-ui/src/index.ts
+++ b/packages/admin-ui/src/index.ts
@@ -3,8 +3,10 @@ export * from '@vtex/admin-ui-react'
 export * from '@vtex/admin-ui-hooks'
 export * from '@vtex/admin-ui-util'
 
-export * from './center'
+export * from './next'
 export * from './experimental'
+
+export * from './center'
 export * from './inline'
 export * from './bleed'
 export * from './button'
@@ -12,7 +14,6 @@ export * from './stack'
 export * from './radio'
 export * from './switch'
 export * from './checkbox'
-export * from './text-input'
 
 export * from './deprecated-set'
 

--- a/packages/admin-ui/src/next.ts
+++ b/packages/admin-ui/src/next.ts
@@ -1,0 +1,5 @@
+import type { TextInputProps } from './text-input'
+import { TextInput } from './text-input'
+
+export type { TextInputProps as next_TextInputProps }
+export { TextInput as next_TextInput }

--- a/packages/admin-ui/src/radio/__snapshots__/radio.test.tsx.snap
+++ b/packages/admin-ui/src/radio/__snapshots__/radio.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Radio should match snapshot 1`] = `
 }
 
 .emotion-5 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-0 {

--- a/packages/admin-ui/src/switch/__snapshots__/switch.test.tsx.snap
+++ b/packages/admin-ui/src/switch/__snapshots__/switch.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Switch tests all variants should match snapshot disabled 1`] = `
 }
 
 .emotion-4 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-3 {
@@ -266,7 +266,7 @@ exports[`Switch tests all variants should match snapshot label only 1`] = `
 }
 
 .emotion-4 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-3 {
@@ -509,7 +509,7 @@ exports[`Switch tests all variants should match snapshot with error text 1`] = `
 }
 
 .emotion-6 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-5 {
@@ -761,6 +761,7 @@ exports[`Switch tests all variants should match snapshot with error text 1`] = `
         >
           <span
             class="emotion-2"
+            role="alert"
           >
             Error text
           </span>
@@ -792,7 +793,7 @@ exports[`Switch tests all variants should match snapshot with help and error tex
 }
 
 .emotion-7 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-6 {
@@ -1058,6 +1059,7 @@ exports[`Switch tests all variants should match snapshot with help and error tex
           </span>
           <span
             class="emotion-3"
+            role="alert"
           >
             Error text
           </span>
@@ -1089,7 +1091,7 @@ exports[`Switch tests all variants should match snapshot with help text 1`] = `
 }
 
 .emotion-6 >*:not(:first-child) {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .emotion-5 {

--- a/packages/admin-ui/src/text-input/text-input.style.ts
+++ b/packages/admin-ui/src/text-input/text-input.style.ts
@@ -1,6 +1,9 @@
 import { style, styleVariants } from '@vtex/admin-ui-core'
 
+const height = '2.75rem'
+
 export const container = style({
+  height,
   display: 'flex',
   width: '100%',
   alignItems: 'center',
@@ -8,6 +11,7 @@ export const container = style({
   border: '$form.neutral',
   borderRadius: '$default',
   bg: '$form.neutral',
+  cursor: 'text',
   ':hover': {
     border: '$form.neutralHover',
   },
@@ -45,6 +49,7 @@ export const containerVariants = styleVariants({
 })
 
 export const input = style({
+  height,
   padding: '$m',
   width: '100%',
   borderRadius: '$default',

--- a/packages/admin-ui/src/text-input/text-input.tsx
+++ b/packages/admin-ui/src/text-input/text-input.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, ComponentPropsWithoutRef, Ref } from 'react'
-import React, { forwardRef } from 'react'
-import { useId } from '@vtex/admin-ui-hooks'
+import React, { useRef, forwardRef } from 'react'
+import { useId, useForkRef } from '@vtex/admin-ui-hooks'
 
 import { TextInputContainer } from './text-input-container'
 import { TextInputElement } from './text-input-element'
@@ -26,16 +26,24 @@ export const TextInput = forwardRef(
     } = props
 
     const id = useId(defaultId)
+    const innerRef = useRef<HTMLInputElement>(null)
+
+    const focus = () => {
+      if (innerRef.current) {
+        innerRef.current.focus()
+      }
+    }
 
     return (
       <FormControl error={error}>
         {label && <FormControlLabel htmlFor={id}>{label}</FormControlLabel>}
-        <TextInputContainer error={error} disabled={disabled}>
+        <TextInputContainer onClick={focus} error={error} disabled={disabled}>
           {prefix && <TextInputTerm type="prefix">{prefix}</TextInputTerm>}
           <TextInputElement
-            ref={ref}
+            ref={useForkRef(innerRef, ref)}
             disabled={disabled}
             id={id}
+            aria-invalid={error ? 'true' : 'false'}
             {...inputProps}
           />
           {suffix && <TextInputTerm type="suffix">{suffix}</TextInputTerm>}


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
- Fix form-control spaces to match Figma.
- Fix form-control message a11y.
- Fix the text-input click/focus behavior.
- Add the `next` terminology to the text-input to avoid confusion.

#### What problem is this solving?
Admin UI should match Figma and be inclusive to every user.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
