### PR TITLE
Add Stitches to admin-ui-core

### DIFF
--- a/packages/admin-ui-core/package.json
+++ b/packages/admin-ui-core/package.json
@@ -25,15 +25,12 @@
     "url": "https://github.com/vtex/admin-ui/issues"
   },
   "peerDependencies": {
-    "@emotion/css": ">=11",
     "react": ">=16.8",
     "react-dom": ">=16.8"
   },
-  "devDependencies": {
-    "@emotion/css": "11.7.1"
-  },
   "dependencies": {
     "@vtex/admin-ui-util": "^0.3.0",
-    "csstype": "3.0.10"
+    "csstype": "3.0.10",
+    "@stitches/core": "1.2.8"
   }
 }

--- a/packages/admin-ui-core/src/__stories__/core.stories.tsx
+++ b/packages/admin-ui-core/src/__stories__/core.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import type { Meta } from '@storybook/react'
-import createEmotion from '@emotion/css/create-instance'
 
 import { createCsx } from '../index'
 
@@ -8,28 +7,26 @@ export default {
   title: 'admin-ui-core/core',
 } as Meta
 
-// create a emotion instance
-const emotion = createEmotion({
-  key: 'admin-ui-core',
-})
-
 // join the parser w/ emotion.css
-const csx = createCsx(emotion)
+const csx = createCsx()
 
 export function FrameworkdAgnostic() {
   return (
     <div
       className={csx({
-        bg: '$secondary',
+        bg: '$action.neutral.tertiary',
         color: '$primary',
         border: '$neutral',
+        ':hover': {
+          bg: '$action.neutral.tertiaryHover',
+        },
         padding: 1,
         marginY: 2,
         size: 150,
         borderRadius: 4,
       })}
     >
-      Framework Agnostic Box
+      <div className="test">Framework Agnostic Box</div>
     </div>
   )
 }

--- a/packages/admin-ui-core/src/__stories__/core.stories.tsx
+++ b/packages/admin-ui-core/src/__stories__/core.stories.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 import type { Meta } from '@storybook/react'
 
 import { createCsx } from '../index'
+import { theme } from '../theme'
 
 export default {
   title: 'admin-ui-core/core',
 } as Meta
 
 // join the parser w/ emotion.css
-const csx = createCsx()
+const csx = createCsx(theme)
 
 export function FrameworkdAgnostic() {
   return (
@@ -20,13 +21,19 @@ export function FrameworkdAgnostic() {
         ':hover': {
           bg: '$action.neutral.tertiaryHover',
         },
+        div: {
+          bg: '$secondary',
+        },
         padding: 1,
         marginY: 2,
         size: 150,
         borderRadius: 4,
       })}
     >
-      <div className="test">Framework Agnostic Box</div>
+      <div className={csx({ '+ button': { bg: '$action.critical.primary' } })}>
+        Framework Agnostic Box
+      </div>
+      <button>test button</button>
     </div>
   )
 }

--- a/packages/admin-ui-core/src/aliases.ts
+++ b/packages/admin-ui-core/src/aliases.ts
@@ -7,6 +7,18 @@ const breakpoints = {
   widescreen: '75em',
 }
 
+export function convertChainedSelectors(key: string) {
+  if (key.startsWith(':')) {
+    return `&${key}`
+  }
+
+  if (key.startsWith('.')) {
+    return `& ${key}`
+  }
+
+  return key
+}
+
 export const aliases = {
   // color
   bg: 'background',
@@ -20,5 +32,7 @@ export const aliases = {
 }
 
 export function alias(prop: string) {
-  return get(aliases, prop, prop)
+  const converted = convertChainedSelectors(prop)
+
+  return get(aliases, converted, converted)
 }

--- a/packages/admin-ui-core/src/aliases.ts
+++ b/packages/admin-ui-core/src/aliases.ts
@@ -8,15 +8,18 @@ const breakpoints = {
 }
 
 export function convertChainedSelectors(key: string) {
-  if (key.startsWith(':')) {
-    return `&${key}`
-  }
+  const joinedSelectors = ['[', ':']
+  const spacedSelectors = ['.', '+']
 
-  if (key.startsWith('.')) {
-    return `& ${key}`
-  }
+  const isJoined = joinedSelectors.find((selector) => key.startsWith(selector))
+  const isSpaced = spacedSelectors.find((selector) => key.startsWith(selector))
 
-  return key
+  const joinedSelector = isJoined && `&${key}`
+  const spacedSelector = isSpaced && `& ${key}`
+
+  const converted = joinedSelector ?? spacedSelector ?? key
+
+  return converted
 }
 
 export const aliases = {

--- a/packages/admin-ui-core/src/styles.ts
+++ b/packages/admin-ui-core/src/styles.ts
@@ -1,5 +1,5 @@
-import type { Emotion } from '@emotion/css/create-instance'
-import type { CSSObject as EmotionCSSObject } from '@emotion/css'
+import type { CSS as CSSObject } from '@stitches/core'
+import { css } from '@stitches/core'
 import { isFunction } from '@vtex/admin-ui-util'
 
 import { alias } from './aliases'
@@ -69,7 +69,7 @@ function resolveResponsiveArray(
  * Parses a style object
  */
 export function styles(csxObject: StyleProp = {}, theme: any = defaultTheme) {
-  const cssObject: EmotionCSSObject = {}
+  const cssObject: CSSObject = {}
   const responsive = resolveResponsiveArray(csxObject as any)
 
   for (const key in responsive) {
@@ -110,12 +110,12 @@ export function styles(csxObject: StyleProp = {}, theme: any = defaultTheme) {
   return cssObject
 }
 
-export function createCsx(emotion: Emotion, theme?: any) {
+export function createCsx(theme?: any) {
   function csx(csxObject: StyleProp) {
-    const emotionCSSObject = styles(csxObject, theme)
-    const className = emotion.css(emotionCSSObject)
+    const stitchesCSSObject = styles(csxObject, theme)
+    const className = css(stitchesCSSObject)
 
-    return className
+    return className()
   }
 
   return csx

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,17 +1986,6 @@
     "@emotion/memoize" "^0.7.4"
     stylis "4.0.13"
 
-"@emotion/css@11.7.1":
-  version "11.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.7.1.tgz#516b717340d36b0bbd2304ba7e1a090e866f8acc"
-  integrity sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==
-  dependencies:
-    "@emotion/babel-plugin" "^11.7.1"
-    "@emotion/cache" "^11.7.1"
-    "@emotion/serialize" "^1.0.0"
-    "@emotion/sheet" "^1.0.3"
-    "@emotion/utils" "^1.0.0"
-
 "@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
@@ -2074,7 +2063,7 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
-"@emotion/serialize@^1.0.0", "@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.3":
+"@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.3.tgz#99e2060c26c6292469fb30db41f4690e1c8fea63"
   integrity sha512-2mSSvgLfyV3q+iVh3YWgNlUc2a9ZlDU7DjuP5MjK3AXRR0dYigCrP99aeFtaB2L/hjfEZdSThn5dsZ0ufqbvsA==
@@ -4205,6 +4194,11 @@
     cheerio "^0.22.0"
     eval "^0.1.8"
     webpack-sources "^1.4.3"
+
+"@stitches/core@1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-1.2.8.tgz#dce3b8fdc764fbc6dbea30c83b73bfb52cf96173"
+  integrity sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==
 
 "@storybook/addon-a11y@^6.4.19":
   version "6.4.22"


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

* Add Stitches [framework agnostic API](https://stitches.dev/docs/framework-agnostic) to the admin-ui-core package and replace the Emotion CSS function with the Stitches one.
* Add a chained selector alias in order to minimize the breaking changes when switching to `Stitches css`
> In Emotion, pseudo-classes and pseudo-selectors are automatically chained to the scoped selector. However, other selectors, such as class or id selectors, require the & sign, otherwise they're considered descendants. 
In Stitches, all chained selectors require the & sign.

[Detailed info about migrating from emotion to Stitches](https://stitches.dev/blog/migrating-from-emotion-to-stitches)

[Detailed info about why choosing the framework agnostic API instead of the @stitches/react](https://vtex-dev.atlassian.net/browse/NAD-1135?focusedCommentId=62074)

#### How should this be manually tested?
<!--- Usually `yarn and yarn test`, but feel encouraged to add a more descriptive explanation. -->

You can check the `admin-ui-core` stories to see that the admin-ui `csx` is already working with the Stitches under the hood instead of emotion.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
