### PR TITLE
Feat/automated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🚨
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - Semver-Patch
+        - bug
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,16 +7,13 @@ changelog:
   categories:
     - title: Breaking Changes 🚨
       labels:
-        - Semver-Major
-        - breaking-change
+        - 🚨 breaking change
     - title: Exciting New Features 🎉
       labels:
-        - Semver-Minor
-        - enhancement
+        - 🆕 feature
     - title: Bug Fixes 🐛
       labels:
-        - Semver-Patch
-        - bug
+        - 🐛 bug
     - title: Other Changes
       labels:
         - '*'


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?

To partially automate (one step towards fully automating it) release notes generation based on merged PR labels:

- `🚨 breaking change`
- `🐛 bug`
- `🆕 feature`

The `release.yml` file structures our release notes generated by Github.

![image](https://user-images.githubusercontent.com/33183880/170059444-c9385039-d833-4909-abe9-39e703ed5106.png)

#### What problem is this solving?

We have to manually type the release notes nowadays. This could be done in a different manner.

#### How should this be manually tested?

You can visit the test repo I created in order to test this feature, and take a look at the generated release notes: https://github.com/marcelovicentegc/release-notes-test/releases.

Also, visit and read Github's documentation on this: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly