### PR TITLE
fix: fix code preview container to show menu popover correctly

### DIFF
--- a/packages/admin-ui-docs/src/components/CodePreviewContainer/index.tsx
+++ b/packages/admin-ui-docs/src/components/CodePreviewContainer/index.tsx
@@ -21,13 +21,15 @@ export function CodePreviewContainer(props: CodeSectionProps) {
     ? 'preview-grid-container'
     : 'preview-default-container'
 
+  const wrapperClassName = isGridLayout ? 'wrapper-container' : ''
+
   const gridTemplateColumns =
     isGridLayout && isTabletScreen
       ? `repeat(${props.columnsCount}, 1fr)`
       : `1fr`
 
   return (
-    <div className="wrapper-container">
+    <div className={wrapperClassName}>
       <tag.div
         className={className}
         csx={{


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Fix code preview container to show menu popover correctly

#### What problem is this solving?
The menu popover is getting stuck inside the code preview and it should be rendered outside the code preview container.

**Before**
<img width="824" alt="Screen Shot 2022-06-10 at 12 46 40" src="https://user-images.githubusercontent.com/991309/173103026-3ce78ac1-4ccc-4cd8-82c1-808cd758bd67.png">

**After**
<img width="829" alt="Screen Shot 2022-06-10 at 12 48 24" src="https://user-images.githubusercontent.com/991309/173103294-cac77c52-9f7b-4344-a569-9eafee552c74.png">

#### How should this be manually tested?
Check the menu component page

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
