### PR TITLE
fix(combobox): fix delay on empty state when just one letter is typed

### DIFF
--- a/packages/admin-ui/src/combobox/combobox.state.ts
+++ b/packages/admin-ui/src/combobox/combobox.state.ts
@@ -68,7 +68,7 @@ export function useComboboxState<T>(
 
     const noMatches = !matches.length
 
-    if (noMatches && deferredValue === '') {
+    if (noMatches && state.value === '') {
       return 'empty-search'
     }
 


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Fix delay on empty state when just one letter is typed on combobox, when the user types just one letter they get the message "start typing". That doesn't make sense

#### What problem is this solving?
When the user types just one letter they get the message "start typing". That doesn't make sense

https://user-images.githubusercontent.com/8623116/173876068-c9e866dc-4fbb-4150-aa49-2cabc54a1f8d.mov

#### How should this be manually tested?
check combobox on storybook see if issue is fixed, check other states too

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly


