### PR TITLE
fix(docs): fix search for iconography and design tokens

### DIFF
--- a/packages/admin-ui-docs/src/components/IconsGrid/icons.tsx
+++ b/packages/admin-ui-docs/src/components/IconsGrid/icons.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import * as AdminUI from '@vtex/admin-ui'
-import type { Icon } from '@vtex/phosphor-icons'
 
 function generateMap() {
-  iconsDoc.sort((a, b) => {
+  const icons = [...iconsDoc].sort((a, b) => {
     if (a < b) return -1
     if (a > b) return 1
 
     return 0
   })
 
-  return iconsDoc.map((name) => {
-    const Icon = (AdminUI as Record<string, any>)[`Icon${name}`] as Icon
+  return icons.map((name) => {
+    const Icon = AdminUI[`Icon${name}`]
 
     return {
+      id: name,
       name,
       icon: <Icon />,
     }
@@ -25,7 +25,7 @@ export interface IconProps {
   size?: number
 }
 
-export const iconsDoc = [
+const iconsDoc = [
   'CaretUp',
   'CaretDown',
   'CaretLeft',
@@ -127,7 +127,7 @@ export const iconsDoc = [
   'Cube',
   'ShareNetwork',
   'Stack',
-]
+] as const
 
 export const filled = ['Warning', 'Bell', 'Envelope', 'XOctagon']
 export const small = [

--- a/packages/admin-ui-docs/src/components/IconsGrid/index.tsx
+++ b/packages/admin-ui-docs/src/components/IconsGrid/index.tsx
@@ -82,7 +82,7 @@ export function IconsGrid(props: IconsGridProps) {
   return (
     <DataView state={dataView} csx={{ marginX: 2 }}>
       <DataViewControls>
-        <Search state={search} />
+        <Search {...search.getInputProps()} />
         <Dropdown
           label="Sizes"
           state={sizeDropdown}

--- a/packages/admin-ui-docs/src/components/TokensTable/index.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/index.tsx
@@ -53,10 +53,10 @@ export function TokensTable(props: TokensTableProps) {
     [dropdown.selectedItem]
   )
 
+  const searchLowerCase = search.debouncedValue.toLocaleLowerCase()
+
   const searchedItems = React.useMemo(() => {
     return items.filter((item) => {
-      const searchLowerCase = search.debouncedValue.toLocaleLowerCase()
-
       if (filter !== 'all' && filter !== item.type.toLowerCase()) return false
 
       const isSearchedTextInValueColumn =
@@ -70,7 +70,7 @@ export function TokensTable(props: TokensTableProps) {
         isSearchedTextInValueColumn
       )
     })
-  }, [search])
+  }, [searchLowerCase])
 
   useEffect(() => {
     if (!searchedItems.length) {

--- a/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
+++ b/packages/admin-ui-docs/src/components/TokensTable/tokens.tsx
@@ -88,4 +88,7 @@ export const tokens = [
   ...border,
   ...shadow,
   ...text,
-]
+].map((token, index) => ({
+  id: index,
+  ...token,
+}))


### PR DESCRIPTION
#### What is the purpose of this pull request? / What problem is this solving?

- Fix the documentation which today doesn't works the search field for the `Guidelines > Design Tokens` and `Guidelines > Typography`

#### How should this be manually tested?
- Runs `yarn start` on `admin-ui-docs` and try to search something on the `Design Tokens` and `Iconography`

#### Screenshots or example usage

![design-tokens](https://user-images.githubusercontent.com/8618687/174390368-43a6a72f-ba7c-4092-9c18-c33a1c8b1336.png)

![iconography](https://user-images.githubusercontent.com/8618687/174390381-84b66ef1-edf5-4862-8557-a66a79742a6b.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media2.giphy.com/media/3o7TKtqGijzhN6aNaw/giphy.gif?cid=ecf05e47lobbdx5r9x7v4d3dej5rxabmppq6m0uuff5iy2mp&rid=giphy.gif&ct=g)
