### PR TITLE
Add responsive value using the responsive aliases

### DIFF
--- a/packages/admin-ui-core/src/aliases.ts
+++ b/packages/admin-ui-core/src/aliases.ts
@@ -1,11 +1,7 @@
 import { get } from '@vtex/admin-ui-util'
+import { breakpoints } from './tokens/breakpoints'
 
-const breakpoints = {
-  mobile: '40em',
-  tablet: '48em',
-  desktop: '64em',
-  widescreen: '75em',
-}
+const [_, tablet, desktop, widescreen] = breakpoints
 
 export function convertChainedSelectors(key: string) {
   const selector = '&'
@@ -28,11 +24,11 @@ export const aliases = {
   bg: 'background',
 
   // responsive
-  '@tablet': `@media (min-width: ${breakpoints.tablet})`,
-  '@tabletOnly': `@media (min-width: ${breakpoints.tablet}) and (max-width: ${breakpoints.desktop})`,
-  '@desktop': `@media (min-width: ${breakpoints.desktop})`,
-  '@desktopOnly': `@media (min-width: ${breakpoints.desktop}) and (max-width: ${breakpoints.widescreen})`,
-  '@widescreen': `@media (min-width: ${breakpoints.widescreen})`,
+  '@tablet': `@media (min-width: ${tablet})`,
+  '@tabletOnly': `@media (min-width: ${tablet}) and (max-width: ${desktop})`,
+  '@desktop': `@media (min-width: ${desktop})`,
+  '@desktopOnly': `@media (min-width: ${desktop}) and (max-width: ${widescreen})`,
+  '@widescreen': `@media (min-width: ${widescreen})`,
 }
 
 export function alias(prop: string) {

--- a/packages/admin-ui-docs/docs/introduction/developing/styling.mdx
+++ b/packages/admin-ui-docs/docs/introduction/developing/styling.mdx
@@ -294,6 +294,36 @@ const layout = style({
 })
 ```
 
+### Responsive Value
+
+Properties of components with the type `ResponsiveValue<T>` indicate that you can use them to behave similarly to responsive aliases by passing different values ​​depending on the screen size
+You can [check the mental model section](#mental-model) to see how the responsiveness works in these cases.
+
+```ts
+interface ResponsiveValue<T> = T | {
+  mobile: T
+  tablet?: T
+  desktop?: T
+  widescreen?: T
+}
+```
+
+#### Example
+
+```jsx live
+<Stack
+  space={{ mobile: '$l', desktop: '$2xl' }}
+  fluid={{ mobile: true, tablet: false }}
+  direction={{ mobile: 'column', tablet: 'row' }}
+>
+  <Button>First</Button>
+  <Button>Second</Button>
+  <Button>Third</Button>
+  <Button>Fourth</Button>
+  <Button>Fifth</Button>
+</Stack>
+```
+
 ### Additional resources
 
 - [Learn responsive design](https://web.dev/learn/design/).

--- a/packages/admin-ui-docs/docs/introduction/developing/styling.mdx
+++ b/packages/admin-ui-docs/docs/introduction/developing/styling.mdx
@@ -294,13 +294,13 @@ const layout = style({
 })
 ```
 
-### Responsive Value
+### Responsive Prop
 
-Properties of components with the type `ResponsiveValue<T>` indicate that you can use them to behave similarly to responsive aliases by passing different values ​​depending on the screen size
+Properties of components with the type `ResponsiveProp<T>` indicate that you can use them to behave similarly to responsive aliases by passing different values ​​depending on the screen size
 You can [check the mental model section](#mental-model) to see how the responsiveness works in these cases.
 
 ```ts
-interface ResponsiveValue<T> = T | {
+interface ResponsiveProp<T> = T | {
   mobile: T
   tablet?: T
   desktop?: T

--- a/packages/admin-ui-react/src/__tests__/use-breakpoint.test.tsx
+++ b/packages/admin-ui-react/src/__tests__/use-breakpoint.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { tokens } from '@vtex/admin-ui-core'
+
+import { useBreakpoint, getResponsiveValue } from '../hooks'
+
+type Matches = boolean | Record<string, boolean>
+
+const createMockMediaMatcher =
+  (matchesOrMapOfMatches: Matches) => (qs: string) =>
+    ({
+      matches:
+        typeof matchesOrMapOfMatches === 'object'
+          ? matchesOrMapOfMatches[qs]
+          : matchesOrMapOfMatches,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    } as unknown as MediaQueryList)
+
+const [mobile, tablet, desktop, widescreen] = tokens.breakpoints
+
+describe('useBreakpoint test', () => {
+  describe('Desktop environment', () => {
+    beforeEach(() => {
+      const matches = {
+        [`(min-width: ${mobile})`]: true,
+        [`(min-width: ${tablet})`]: true,
+        [`(min-width: ${desktop})`]: true,
+        [`(min-width: ${widescreen})`]: false,
+      }
+
+      window.matchMedia = createMockMediaMatcher(matches)
+    })
+
+    it('should match desktop breakpoint', () => {
+      const {
+        result: {
+          current: { breakpoint },
+        },
+      } = renderHook(() => useBreakpoint())
+
+      expect(breakpoint).toBe('desktop')
+    })
+
+    it('should not match tablet breakpoint', () => {
+      const {
+        result: {
+          current: { breakpoint },
+        },
+      } = renderHook(() => useBreakpoint())
+
+      expect(breakpoint).not.toBe('tablet')
+    })
+  })
+
+  describe('Mobile environment', () => {
+    beforeEach(() => {
+      const matches = {
+        [`(min-width: ${mobile})`]: true,
+        [`(min-width: ${tablet})`]: false,
+        [`(min-width: ${desktop})`]: false,
+        [`(min-width: ${widescreen})`]: false,
+      }
+
+      window.matchMedia = createMockMediaMatcher(matches)
+    })
+
+    it('should match mobile breakpoint', () => {
+      const {
+        result: {
+          current: { breakpoint },
+        },
+      } = renderHook(() => useBreakpoint())
+
+      expect(breakpoint).toBe('mobile')
+    })
+
+    it('should not match desktop breakpoint', () => {
+      const {
+        result: {
+          current: { breakpoint },
+        },
+      } = renderHook(() => useBreakpoint())
+
+      expect(breakpoint).not.toBe('desktop')
+    })
+  })
+})
+
+describe('getResponsiveValue test', () => {
+  it('should match mobile breakpoint', () => {
+    const prop = getResponsiveValue({ mobile: 1, desktop: 2 }, 'mobile')
+
+    expect(prop).toBe(1)
+  })
+
+  it('should match desktop breakpoint', () => {
+    const prop = getResponsiveValue({ mobile: 1, desktop: 2 }, 'desktop')
+
+    expect(prop).toBe(2)
+  })
+
+  it(`should match the tablet value, which is the minimum breakpoint when it doesn't have a direct match`, () => {
+    const prop = getResponsiveValue({ mobile: 1, tablet: 2 }, 'widescreen')
+
+    expect(prop).toBe(2)
+  })
+
+  it(`should match the mobile value, which is the minimum breakpoint when it doesn't have a direct match`, () => {
+    const prop = getResponsiveValue({ mobile: 1, widescreen: 2 }, 'desktop')
+
+    expect(prop).toBe(1)
+  })
+})

--- a/packages/admin-ui-react/src/hooks/index.ts
+++ b/packages/admin-ui-react/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-media-query'
+export * from './use-breakpoint'

--- a/packages/admin-ui-react/src/hooks/use-breakpoint.ts
+++ b/packages/admin-ui-react/src/hooks/use-breakpoint.ts
@@ -34,17 +34,17 @@ export function useBreakpoint() {
  * @param breakpoint desired breakpoint
  * @example
  * const { prop } = props
- * const [breakpoint] = useBreakpoint()
+ * const { breakpoint } = useBreakpoint()
  * const responsiveProp = getResponsiveValue(prop, breakpoint)
  */
 export function getResponsiveValue<T>(
   prop: ResponsiveProp<T>,
   breakpoint: Breakpoint,
   index?: number
-): T | null {
+): T {
   if (typeof prop !== 'object') return prop
 
-  if (index && index < 0) return null
+  if (index && index < 0) return get(prop as ResponsiveValue<T>, 'mobile')
 
   const breakpoints = ['mobile', 'tablet', 'desktop', 'widescreen']
 

--- a/packages/admin-ui/src/stack/stack.ts
+++ b/packages/admin-ui/src/stack/stack.ts
@@ -1,9 +1,13 @@
 import type { ComponentPropsWithoutRef } from 'react'
-import { useElement, createHook, createComponent } from '@vtex/admin-ui-react'
+import type { ResponsiveProp } from '@vtex/admin-ui-react'
+import {
+  useElement,
+  createHook,
+  createComponent,
+  useBreakpoint,
+  getResponsiveValue,
+} from '@vtex/admin-ui-react'
 import type { CSSPropAutocomplete, SpaceTokens } from '@vtex/admin-ui-core'
-
-import type { ResponsiveProp } from './responsive'
-import { useBreakpoint, getResponsiveValue } from './responsive'
 
 /**
  * Stack behavior


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Add a solution that make component properties able to use responsive aliases. This is a replacement for the deprecated way of adding responsiveness to properties using responsive arrays

**Before**

```jsx
<Component prop={[1, 2, 3, 4]} />
<Component prop={[1, 2, null, 4]} />
<Component prop={[1, 2]} />
```

**After**

```jsx
<Component prop={{ mobile: 1, tablet: 2, desktop: 3, widescreen: 4 }} />
<Component prop={{ mobile: 1, tablet: 2, widescreen: 4 }} />
<Component prop={{ mobile: 1, tablet: 2 }} />
``` 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
