### PR TITLE
refactor(table): avoid row re-renders when using custom resolvers wit…

### DIFF
--- a/packages/admin-ui/src/table/components/table-body.tsx
+++ b/packages/admin-ui/src/table/components/table-body.tsx
@@ -7,6 +7,10 @@ import { useStateContext } from '../context'
 import { TableCell } from './table-cell'
 import { useDataViewContext } from '../../components/DataView'
 import { useSelectionTreeContext } from '../../components/SelectionTree'
+
+import type { TableColumn } from '../types'
+import type { BaseResolvers } from '../resolvers/base'
+
 import * as styles from '../styles/table-body.styles'
 
 export const TableBody = createComponent<'tbody', TableBodyOptions>((props) => {
@@ -69,7 +73,7 @@ export const TableBodyRow = createComponent<'tr', TableBodyRowOptions>(
     const { item = {}, role = 'row', children, ...rowProps } = props
 
     const { status } = useDataViewContext()
-    const { onRowClick, columns, resolveCell } = useStateContext()
+    const { onRowClick, columns } = useStateContext()
 
     const clickable = onRowClick && !(status === 'loading')
 
@@ -102,29 +106,49 @@ export const TableBodyRow = createComponent<'tr', TableBodyRowOptions>(
       },
       role,
       children: (
-        <Fragment>
-          {columns.map((column) => {
-            const content = resolveCell({ item, column })
-
-            return (
-              <Fragment key={`${item.id}-${String(column.id)}`}>
-                {children ? (
-                  cloneElement(children as any, {
-                    column,
-                    children: <Fragment>{content}</Fragment>,
-                  })
-                ) : (
-                  <TableCell column={column}>{content}</TableCell>
-                )}
-              </Fragment>
-            )
-          })}
-        </Fragment>
+        <>
+          {columns.map((column) => (
+            <TableBodyCell
+              item={item}
+              column={column}
+              key={`${String(item.id)}-${String(column.id)}`}
+            >
+              {children}
+            </TableBodyCell>
+          ))}
+        </>
       ),
       onClick: handleClick,
     })
   }
 )
+
+const TableBodyCell = (props: TableBodyCellOptions) => {
+  const { resolveCell } = useStateContext()
+
+  const { item, column, children } = props
+
+  const content = resolveCell({ item, column })
+
+  return (
+    <>
+      {children ? (
+        cloneElement(children as any, {
+          column,
+          children: content,
+        })
+      ) : (
+        <TableCell column={column}>{content}</TableCell>
+      )}
+    </>
+  )
+}
+
+export interface TableBodyCellOptions {
+  item?: Record<string, any>
+  column: TableColumn<any, BaseResolvers<any>>
+  children: ReactNode
+}
 
 export interface TableBodyRowOptions {
   item?: Record<string, any>


### PR DESCRIPTION
…h state

<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Improve table issues performance

#### What problem is this solving?
Avoid row re-renders when using custom resolvers with state in a single cell

### Before
https://user-images.githubusercontent.com/991309/177777263-1d3c97ad-4cf3-4f12-8f48-35c94db259e3.mov

### After
https://user-images.githubusercontent.com/991309/177777662-26ce2d08-c2bb-48da-9f11-dfd72202c097.mov

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
