### PR TITLE
fix(menu-button): add onClick to MenuButton props

### DIFF
--- a/packages/admin-ui/src/menu/menu-button.tsx
+++ b/packages/admin-ui/src/menu/menu-button.tsx
@@ -140,6 +140,10 @@ export type MenuButtonOptions = VariantProps<
    * Horizontal bleed
    */
   bleedX?: boolean
+  /**
+   * Button click event
+   */
+  onClick?: React.MouseEventHandler<HTMLButtonElement>
 }
 
 export type MenuButtonProps = React.ComponentPropsWithoutRef<typeof MenuButton>


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Add onClick to MenuButton props

#### What problem is this solving?
`vtex link` is breaking because it doesn't acknowledge `onClick` as `MenuButton` prop

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
