### PR TITLE
fix(border): helper function to apply border style not working

### DIFF
--- a/packages/admin-ui-core/src/__tests__/styles.test.ts
+++ b/packages/admin-ui-core/src/__tests__/styles.test.ts
@@ -1,6 +1,7 @@
 import { get } from '@vtex/admin-ui-util'
 
-import { cx, styles } from '../styles'
+import { styles } from '../styles'
+import { cx } from '../helpers'
 
 describe('styles', () => {
   describe('edge cases', () => {

--- a/packages/admin-ui-core/src/helpers.ts
+++ b/packages/admin-ui-core/src/helpers.ts
@@ -4,6 +4,8 @@ import { paletteMap } from './types'
 import type { Palette, Tone, ColorTokens, StyleProp, CSSUnit } from './types'
 import { colors } from './tokens/colors'
 
+const TOKEN_PREFIX = '$'
+
 export function ring(tone: Tone) {
   const lighterColor = get(colors, `${paletteMap[tone]}05`)
   const darkerColor = get(colors, `${paletteMap[tone]}30`)
@@ -22,7 +24,7 @@ export function palette(color: Palette): StyleProp {
 }
 
 export function color(token: ColorTokens) {
-  return get(colors, token, '')
+  return get(colors, extractTokenCall(token), '')
 }
 
 export function listBoxItem(tone: 'main' | 'critical', selected = false) {
@@ -62,7 +64,7 @@ export function focusVisible(
 }
 
 export function border(ct: ColorTokens, widthPx = 1): string {
-  return `${widthPx}px solid ${get(colors, ct)}`
+  return `${widthPx}px solid ${get(colors, extractTokenCall(ct))}`
 }
 
 export function withUnit(value: unknown, unit: CSSUnit): string {
@@ -72,3 +74,13 @@ export function withUnit(value: unknown, unit: CSSUnit): string {
 export function negative(token: string): string {
   return token.startsWith('$') ? `$-${token.substring(1)}` : `-${token}`
 }
+
+export function isToken(token: string) {
+  return typeof token === 'string' && token.startsWith(TOKEN_PREFIX)
+}
+
+export function extractTokenCall(token: string) {
+  return isToken(token) ? token.substring(1) : token
+}
+
+export const cx = (...args: string[]) => args.join(' ')

--- a/packages/admin-ui-core/src/styles.ts
+++ b/packages/admin-ui-core/src/styles.ts
@@ -8,8 +8,7 @@ import { callUtil, isUtil } from './utils'
 import { createTransform } from './transforms'
 import type { StyleObject, StyleProp } from './types'
 import { theme as defaultTheme } from './theme'
-
-const TOKEN_PREFIX = '$'
+import { extractTokenCall } from './helpers'
 
 /**
  * Parses a style object
@@ -55,13 +54,3 @@ export function createCsx(theme?: any) {
 
   return csx
 }
-
-export function isToken(token: string) {
-  return typeof token === 'string' && token.startsWith(TOKEN_PREFIX)
-}
-
-export function extractTokenCall(token: string) {
-  return isToken(token) ? token.substring(1) : token
-}
-
-export const cx = (...args: string[]) => args.join(' ')


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fix the `border` helper function used to apply border styles. The issue is that the function is trying to access the theme colors using a value with the `$` token prefix, but it's necessary to remove it before accessing.

#### How should this be manually tested?
<!--- Usually `yarn and yarn test`, but feel encouraged to add a more descriptive explanation. -->
Check that before the components borders weren't being rendered with color, but now everything works.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
