### PR TITLE
fix(tab): use explict types instead of deep inheritance

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "independent",
@@ -9,7 +7,7 @@
   "loglevel": "success",
   "command": {
     "publish": {
-      "allowBranch": ["main", "dev"],
+      "allowBranch": ["main", "dev", "fix/tab-types"],
       "conventionalCommits": true,
       "message": "chore(release): publish [skip ci]"
     }

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
   "loglevel": "success",
   "command": {
     "publish": {
-      "allowBranch": ["main", "dev", "fix/tab-types"],
+      "allowBranch": ["main", "dev"],
       "conventionalCommits": true,
       "message": "chore(release): publish [skip ci]"
     }

--- a/packages/admin-ui/src/tab/stories/tabs.stories.tsx
+++ b/packages/admin-ui/src/tab/stories/tabs.stories.tsx
@@ -48,8 +48,8 @@ export function WithId() {
         <Tab id="2">Tab 2</Tab>
       </TabList>
       <TabPanelList state={state}>
-        <TabPanel id="1">Panel 1</TabPanel>
-        <TabPanel id="2">Panel 2</TabPanel>
+        <TabPanel tabId="1">Panel 1</TabPanel>
+        <TabPanel tabId="2">Panel 2</TabPanel>
       </TabPanelList>
     </>
   )

--- a/packages/admin-ui/src/tab/tab-list.tsx
+++ b/packages/admin-ui/src/tab/tab-list.tsx
@@ -1,22 +1,31 @@
+import type { ReactNode } from 'react'
 import React from 'react'
 import { TabList as AriakitTabList } from 'ariakit'
 import { createComponent, useElement } from '@vtex/admin-ui-react'
 
 import * as style from './tabs.style'
 import { Inline } from '../inline'
+import type { TabState } from './tab.state'
 
-export const TabList = createComponent<typeof AriakitTabList>((props) => {
-  const { children, ...tabListProps } = props
+export const TabList = createComponent<typeof AriakitTabList, TabListOptions>(
+  (props) => {
+    const { children, ...tabListProps } = props
 
-  return useElement(AriakitTabList, {
-    baseStyle: style.tabList,
-    children: (
-      <Inline hSpace="$m" spaceInside>
-        {children}
-      </Inline>
-    ),
-    ...tabListProps,
-  })
-})
+    return useElement(AriakitTabList, {
+      baseStyle: style.tabList,
+      children: (
+        <Inline hSpace="$m" spaceInside>
+          {children}
+        </Inline>
+      ),
+      ...tabListProps,
+    })
+  }
+)
+
+export type TabListOptions = {
+  state: TabState
+  children?: ReactNode
+}
 
 export type TabListProps = React.ComponentPropsWithRef<typeof TabList>

--- a/packages/admin-ui/src/tab/tab-panel-list.tsx
+++ b/packages/admin-ui/src/tab/tab-panel-list.tsx
@@ -21,5 +21,5 @@ export function useTabPanelContext() {
 
 export interface TabPanelListProps {
   state: TabState
-  children: ReactNode
+  children?: ReactNode
 }

--- a/packages/admin-ui/src/tab/tab-panel.tsx
+++ b/packages/admin-ui/src/tab/tab-panel.tsx
@@ -4,6 +4,7 @@ import { createComponent, useElement } from '@vtex/admin-ui-react'
 import { useTabPanelContext } from './tab-panel-list'
 import type { TabState } from './tab.state'
 import * as style from './tabs.style'
+import type { ReactNode } from 'react'
 
 export const TabPanel = createComponent<
   typeof AriakitTabPanel,
@@ -23,6 +24,8 @@ export const TabPanel = createComponent<
 
 export interface TabPanelOptions {
   state?: TabState
+  tabId?: string
+  children?: ReactNode
 }
 
 export type TabPanelProps = React.ComponentPropsWithRef<typeof TabPanel>

--- a/packages/admin-ui/src/tab/tab.tsx
+++ b/packages/admin-ui/src/tab/tab.tsx
@@ -1,13 +1,21 @@
 import { Tab as AriakitTab } from 'ariakit'
 import { createComponent, useElement } from '@vtex/admin-ui-react'
+import type { ReactNode } from 'react'
+import type { TabState } from './tab.state'
 
 import * as style from './tabs.style'
 
-export const Tab = createComponent<typeof AriakitTab>((props) => {
+export const Tab = createComponent<typeof AriakitTab, TabOptions>((props) => {
   return useElement(AriakitTab, {
     ...props,
     baseStyle: style.tab,
   })
 })
+
+export interface TabOptions {
+  state?: TabState
+  id?: string
+  children?: ReactNode
+}
 
 export type TabProps = React.ComponentPropsWithRef<typeof Tab>


### PR DESCRIPTION
#### What is the purpose of this pull request?

VTEX's IO-Render users are experiencing issues regarding the types while linking. This happens due to an old typescript version used by the platform. This fix generates types in a more explicit/traditional/conventional way. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
