### PR TITLE
fix(sidebar): section item skeleton not showing in the loading state

### DIFF
--- a/packages/admin-ui/src/components/Sidebar/__stories__/Sidebar.stories.tsx
+++ b/packages/admin-ui/src/components/Sidebar/__stories__/Sidebar.stories.tsx
@@ -15,7 +15,6 @@ import {
   IconBell,
   IconArrowUUpLeft,
 } from '@vtex/phosphor-icons'
-import { tag } from '@vtex/admin-ui-react'
 import { Topbar, TopbarStart, TopbarEnd } from '../../Topbar'
 import { Box } from '../../../box'
 import { Inline } from '../../../inline'
@@ -57,7 +56,12 @@ const top = [
     icon: <IconChartBar />,
     onClick: () => console.log('Click me'),
     label: 'Home',
-    sections: [],
+    sections: [
+      {
+        title: 'Dashboards',
+        subItems: ['Overview', 'Sales Performance', 'Web Page Performance'],
+      },
+    ],
   },
   {
     icon: <IconShoppingCartSimple />,
@@ -270,14 +274,18 @@ export const Playground: Story<any> = (args) => {
           </SidebarGroup>
           <SidebarGroup>
             {bottom.map((item) => (
-              <tag.a href="https://www.google.com.br" csx={{ width: '100%' }}>
+              <Box
+                as="a"
+                href="https://www.google.com.br"
+                csx={{ width: '100%' }}
+              >
                 <SidebarItem
                   icon={item.icon}
                   label={item.label}
                   uniqueKey={item.label}
                   key={item.label}
                 />
-              </tag.a>
+              </Box>
             ))}
           </SidebarGroup>
         </Sidebar>

--- a/packages/admin-ui/src/components/Sidebar/components/SidebarBackdrop.tsx
+++ b/packages/admin-ui/src/components/Sidebar/components/SidebarBackdrop.tsx
@@ -34,9 +34,6 @@ export const SidebarBackdrop = forwardRef(function SidebarBackdrop(
     loading = false,
   } = props
 
-  const showSidebarItemSkeleton =
-    loading && selectedItem?.expandable && !reduced
-
   return (
     <Fragment>
       <tag.div
@@ -53,7 +50,7 @@ export const SidebarBackdrop = forwardRef(function SidebarBackdrop(
           borderRight: selectedItem?.expandable ? '$neutral' : 'none',
         }}
       >
-        {showSidebarItemSkeleton && <SidebarItemSkeleton />}
+        {loading && <SidebarItemSkeleton />}
       </tag.div>
 
       {loading ? null : (

--- a/packages/admin-ui/src/components/Sidebar/components/SidebarBackdrop.tsx
+++ b/packages/admin-ui/src/components/Sidebar/components/SidebarBackdrop.tsx
@@ -34,6 +34,10 @@ export const SidebarBackdrop = forwardRef(function SidebarBackdrop(
     loading = false,
   } = props
 
+  const showSidebarItemSkeleton = selectedItem
+    ? loading && selectedItem.expandable
+    : loading
+
   return (
     <Fragment>
       <tag.div
@@ -50,7 +54,7 @@ export const SidebarBackdrop = forwardRef(function SidebarBackdrop(
           borderRight: selectedItem?.expandable ? '$neutral' : 'none',
         }}
       >
-        {loading && <SidebarItemSkeleton />}
+        {showSidebarItemSkeleton && <SidebarItemSkeleton />}
       </tag.div>
 
       {loading ? null : (


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Change the Sidebar Skeleton to render always an expanded sidebar. Nowadays is always rendered with a collapsed sidebar 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
