### PR TITLE
refactor(theme): export ThemeProvider without create system

### DIFF
--- a/.storybook/themeDecorator.js
+++ b/.storybook/themeDecorator.js
@@ -1,7 +1,5 @@
 import React from 'react'
-import { createSystem } from '@vtex/admin-ui'
-
-const [ThemeProvider] = createSystem()
+import { ThemeProvider } from '@vtex/admin-ui'
 
 export function themeDecorator(storyFn) {
   return <ThemeProvider>{storyFn()}</ThemeProvider>

--- a/packages/admin-ui-core/src/createTheme.ts
+++ b/packages/admin-ui-core/src/createTheme.ts
@@ -277,9 +277,10 @@ function resolveValue(value: any, ruleId: string, theme: Record<string, any>) {
     const colorValue = get(colors, key)
 
     if (result.includes(colorValue)) {
-      result = result
-        .toString()
-        .replaceAll(colorValue, toVarValue(`colors-${key}`))
+      result = result.replace(
+        new RegExp(colorValue, 'g'),
+        toVarValue(`colors-${key}`)
+      )
     }
   })
 

--- a/packages/admin-ui-core/src/rules.ts
+++ b/packages/admin-ui-core/src/rules.ts
@@ -111,10 +111,6 @@ export const rules = {
   insetInline: 'space',
   insetInlineEnd: 'space',
   insetInlineStart: 'space',
-  top: 'vspace',
-  right: 'hspace',
-  bottom: 'vspace',
-  left: 'hspace',
   gridGap: 'space',
   gap: 'space',
   columnGap: 'space',
@@ -131,6 +127,8 @@ export const rules = {
   scrollPaddingRight: 'hspace',
   scrollPaddingLeft: 'hspace',
   scrollPaddingX: 'hspace',
+  right: 'hspace',
+  left: 'hspace',
 
   // vspace
   gridRowGap: 'vspace',
@@ -143,6 +141,8 @@ export const rules = {
   scrollPaddingTop: 'vspace',
   scrollPaddingBottom: 'vspace',
   scrollPaddingY: 'vspace',
+  top: 'vspace',
+  bottom: 'vspace',
 
   // typography
   text: 'text',

--- a/packages/admin-ui-core/src/styles.ts
+++ b/packages/admin-ui-core/src/styles.ts
@@ -30,9 +30,7 @@ export function styles(csxObject: StyleProp = {}, theme: any = defaultTheme) {
 
     const value = getTokenValue(theme, cssProperty, token)
 
-    if (!!value && typeof value === 'object') {
-      Object.assign(cssObject, value)
-    } else if (isUtil(cssProperty)) {
+    if (isUtil(cssProperty)) {
       Object.assign(cssObject, callUtil(cssProperty, value))
     } else {
       cssObject[cssProperty] = value

--- a/packages/admin-ui-core/src/tests/create-theme.test.ts
+++ b/packages/admin-ui-core/src/tests/create-theme.test.ts
@@ -15,8 +15,6 @@ describe('createTheme', () => {
         global: {},
       },
       cssVariables: {},
-      rootStyleObject: {},
-      rootStyleString: '',
     })
   })
 
@@ -116,21 +114,16 @@ describe('createTheme', () => {
   })
 
   it('should be able to parse the whole theme', () => {
-    const { theme, cssVariables } = createTheme(
-      {
-        colors: {
-          primary: {
-            default: 'red',
-            hover: 'blue',
-            pressed: 'green',
-          },
+    const { theme, cssVariables } = createTheme({
+      colors: {
+        primary: {
+          default: 'red',
+          hover: 'blue',
+          pressed: 'green',
         },
-        space: [0, 1, 2, 3],
       },
-      {
-        enableModes: true,
-      }
-    )
+      space: [0, 1, 2, 3],
+    })
 
     expect(theme).toEqual({
       global: {},
@@ -145,11 +138,9 @@ describe('createTheme', () => {
     })
 
     expect(cssVariables).toEqual({
-      main: {
-        '--admin-ui-colors-primary-default': 'red',
-        '--admin-ui-colors-primary-hover': 'blue',
-        '--admin-ui-colors-primary-pressed': 'green',
-      },
+      '--admin-ui-colors-primary-default': 'red',
+      '--admin-ui-colors-primary-hover': 'blue',
+      '--admin-ui-colors-primary-pressed': 'green',
     })
   })
 

--- a/packages/admin-ui-core/src/tests/styles.test.ts
+++ b/packages/admin-ui-core/src/tests/styles.test.ts
@@ -75,48 +75,21 @@ describe('styles', () => {
         background: 'blue',
       })
     })
-
-    it('should be able to handle splits', () => {
-      const result = styles(
-        {
-          marginX: '$sm',
-          size: 100,
-        },
-        {
-          hspace: {
-            sm: 8,
-          },
-        }
-      )
-
-      expect(result).toEqual({
-        marginLeft: 8,
-        marginRight: 8,
-        height: 100,
-        width: 100,
-      })
-    })
   })
 
   describe('complex rules', () => {
     it('should consume object rules', () => {
-      const result = styles(
-        {
-          text: '$detail',
-        },
-        {
-          text: {
-            detail: {
-              fontSize: 14,
-              fontFamily: 'sans-serif',
-            },
-          },
-        }
-      )
+      const result = styles({
+        text: '$detail',
+      })
 
       expect(result).toEqual({
-        fontSize: 14,
-        fontFamily: 'sans-serif',
+        fontFamily: 'var(--admin-ui-text-detail-fontFamily)',
+        fontSize: 'var(--admin-ui-text-detail-fontSize)',
+        fontVariationSettings:
+          'var(--admin-ui-text-detail-fontVariationSettings)',
+        letterSpacing: 'var(--admin-ui-text-detail-letterSpacing)',
+        lineHeight: 'var(--admin-ui-text-detail-lineHeight)',
       })
     })
 

--- a/packages/admin-ui-core/src/theme.ts
+++ b/packages/admin-ui-core/src/theme.ts
@@ -1,14 +1,6 @@
 import { tokens } from './tokens'
-import type { ThemeOptions } from './createTheme'
 import { createTheme } from './createTheme'
 
-const themeOptions: ThemeOptions = {
-  enableModes: false,
-}
+const { theme, cssVariables } = createTheme(tokens)
 
-const { theme, cssVariables, rootStyleObject, rootStyleString } = createTheme(
-  tokens,
-  themeOptions
-)
-
-export { theme, cssVariables, rootStyleObject, rootStyleString }
+export { theme, cssVariables }

--- a/packages/admin-ui-core/src/utils.ts
+++ b/packages/admin-ui-core/src/utils.ts
@@ -42,6 +42,15 @@ export const utils: Record<string, (value: any) => AnyObject> = {
     maxHeight: value,
   }),
 
+  // Text
+  text: (value: AnyObject) => ({
+    fontFamily: value.fontFamily,
+    fontVariationSettings: value.fontVariationSettings,
+    fontSize: value.fontSize,
+    lineHeight: value.lineHeight,
+    letterSpacing: value.letterSpacing,
+  }),
+
   // Color
   colorTheme: (value: Palette) => palette(value),
 }

--- a/packages/admin-ui-docs/src/theme/Root.js
+++ b/packages/admin-ui-docs/src/theme/Root.js
@@ -1,13 +1,9 @@
 import React from 'react'
 import {
-  createSystem,
+  ThemeProvider,
   ToastProvider,
   experimental_I18nProvider as I18nProvider,
 } from '@vtex/admin-ui'
-
-const [ThemeProvider] = createSystem({
-  experimentalDisabledGlobalStyles: false,
-})
 
 function Root({ children }) {
   return (

--- a/packages/admin-ui-react/src/stories/system.stories.tsx
+++ b/packages/admin-ui-react/src/stories/system.stories.tsx
@@ -14,21 +14,19 @@ import {
 } from 'reakit'
 
 import {
-  createSystem,
+  ThemeProvider,
   createComponent,
   createHook,
   useElement,
 } from '../system'
 
-const [SystemProvider] = createSystem()
-
 export default {
   title: 'admin-ui-react/system',
   decorators: [
     (Story) => (
-      <SystemProvider>
+      <ThemeProvider>
         <Story />
-      </SystemProvider>
+      </ThemeProvider>
     ),
   ],
 } as Meta

--- a/packages/admin-ui-react/src/system/create-system.tsx
+++ b/packages/admin-ui-react/src/system/create-system.tsx
@@ -22,18 +22,20 @@ interface ThemeProviderProps {
   experimentalDisabledGlobalStyles?: boolean
 }
 
+export const csx = createCsx(theme)
+
 export function ThemeProvider(props: ThemeProviderProps) {
   const {
     children,
-    experimentalTheme = theme,
+    experimentalTheme,
     experimentalDisabledGlobalStyles = false,
   } = props
 
-  const csx = createCsx(experimentalTheme)
+  const experimentalCsx = experimentalTheme ? createCsx(experimentalTheme) : csx
 
   const global = experimentalDisabledGlobalStyles
     ? {}
-    : styles(experimentalTheme?.global ?? {})
+    : styles(experimentalTheme?.global ?? theme.global)
 
   globalCss({ ':root': cssVariables, ...global } as any)()
 
@@ -41,7 +43,7 @@ export function ThemeProvider(props: ThemeProviderProps) {
     <SystemContext.Provider
       value={{
         theme: experimentalTheme,
-        cn: csx,
+        cn: experimentalCsx,
         cx,
       }}
     >

--- a/packages/admin-ui-react/src/system/create-system.tsx
+++ b/packages/admin-ui-react/src/system/create-system.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
-import { createCsx, theme, styles, globalCss, cx } from '@vtex/admin-ui-core'
-import type { ReactElement, PropsWithChildren } from 'react'
+import {
+  createCsx,
+  theme,
+  cssVariables,
+  styles,
+  globalCss,
+  cx,
+} from '@vtex/admin-ui-core'
+import type { ReactNode } from 'react'
 import { Helmet } from 'react-helmet'
 
 /** focus-visible polyfill  */
@@ -9,59 +16,47 @@ import 'focus-visible/dist/focus-visible'
 import { IconProvider } from './icons'
 import { SystemContext } from './context'
 
-export function createSystem(
-  spec: CreateSystemOptions = {}
-): CreateSystemReturn {
+interface ThemeProviderProps {
+  children?: ReactNode
+  experimentalTheme?: any
+  experimentalDisabledGlobalStyles?: boolean
+}
+
+export function ThemeProvider(props: ThemeProviderProps) {
   const {
+    children,
     experimentalTheme = theme,
     experimentalDisabledGlobalStyles = false,
-  } = spec
+  } = props
 
   const csx = createCsx(experimentalTheme)
 
   const global = experimentalDisabledGlobalStyles
     ? {}
-    : experimentalTheme.global
+    : styles(experimentalTheme?.global ?? {})
 
-  globalCss(styles(global) as any)()
+  globalCss({ ':root': cssVariables, ...global } as any)()
 
-  function SystemProvider(props: PropsWithChildren<{}>) {
-    const { children } = props
-
-    return (
-      <SystemContext.Provider
-        value={{
-          theme: experimentalTheme,
-          cn: csx,
-          cx,
-        }}
-      >
-        <IconProvider>
-          <Helmet>
-            <link
-              rel="preload"
-              href="https://io.vtex.com.br/fonts/vtex-trust/VTEXTrust-VF-May-5-2022.woff2"
-              as="font"
-              type="font/woff2"
-              crossOrigin="anonymous"
-            />
-          </Helmet>
-          {children}
-        </IconProvider>
-      </SystemContext.Provider>
-    )
-  }
-
-  return [SystemProvider]
+  return (
+    <SystemContext.Provider
+      value={{
+        theme: experimentalTheme,
+        cn: csx,
+        cx,
+      }}
+    >
+      <IconProvider>
+        <Helmet>
+          <link
+            rel="preload"
+            href="https://io.vtex.com.br/fonts/vtex-trust/VTEXTrust-VF-May-5-2022.woff2"
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+        </Helmet>
+        {children}
+      </IconProvider>
+    </SystemContext.Provider>
+  )
 }
-
-export interface CreateSystemOptions {
-  /** Custom theme */
-  experimentalTheme?: any
-  /** Disable global styles */
-  experimentalDisabledGlobalStyles?: boolean
-}
-
-export type CreateSystemReturn = [
-  (props: PropsWithChildren<{}>) => ReactElement
-]

--- a/packages/admin-ui-react/src/test-utils.ts
+++ b/packages/admin-ui-react/src/test-utils.ts
@@ -1,9 +1,7 @@
 import type { ReactElement } from 'react'
 import type { RenderOptions } from '@testing-library/react'
 import { render as baseRender } from '@testing-library/react'
-import { createSystem } from './system'
-
-const [ThemeProvider] = createSystem()
+import { ThemeProvider } from './system'
 
 function render(ui: ReactElement, options?: Omit<RenderOptions, 'queries'>) {
   return baseRender(ui, { wrapper: ThemeProvider, ...options })

--- a/packages/admin-ui/src/checkbox/utils.ts
+++ b/packages/admin-ui/src/checkbox/utils.ts
@@ -1,13 +1,10 @@
-import { get } from '@vtex/admin-ui-util'
-import { theme } from '@vtex/admin-ui-core'
+import { color } from '@vtex/admin-ui-core'
 
 type IconState = 'disabled'
 
 export const checkmarkSvg = (state?: IconState) => {
   const isDisabled = state === 'disabled'
-  const fillColor = isDisabled
-    ? get(theme, 'fg.disabled', '')
-    : get(theme, 'fg.form.controlChecked', '')
+  const fillColor = isDisabled ? color('$gray40') : color('$white')
 
   return `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14.0303 3.96993C14.3232 4.26283 14.3232 4.7377 14.0303 5.03059L7.03032 12.0303C6.73743 12.3231 6.26259 12.3232 5.96969 12.0303L2.46969 8.5306C2.17679 8.23772 2.17677 7.76284 2.46965 7.46994C2.76253 7.17703 3.2374 7.17701 3.53031 7.46989L6.49999 10.4393L12.9697 3.9699C13.2626 3.67702 13.7375 3.67703 14.0303 3.96993Z" fill="${encodeURIComponent(
     fillColor
@@ -16,9 +13,7 @@ export const checkmarkSvg = (state?: IconState) => {
 
 export const indeterminateSvg = (state?: IconState) => {
   const isDisabled = state === 'disabled'
-  const fillColor = isDisabled
-    ? get(theme, 'fg.disabled', '')
-    : get(theme, 'fg.form.controlNeutral', '')
+  const fillColor = isDisabled ? color('$gray40') : color('$black')
 
   return `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.75 8C1.75 7.58579 2.08579 7.25 2.5 7.25H13.5C13.9142 7.25 14.25 7.58579 14.25 8C14.25 8.41421 13.9142 8.75 13.5 8.75H2.5C2.08579 8.75 1.75 8.41421 1.75 8Z" fill="${encodeURIComponent(
     fillColor

--- a/packages/admin-ui/src/test-utils.tsx
+++ b/packages/admin-ui/src/test-utils.tsx
@@ -3,14 +3,12 @@ import React, { useRef } from 'react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import type { RenderOptions } from '@testing-library/react'
 import { render as baseRender, fireEvent, screen } from '@testing-library/react'
-import { createSystem } from '@vtex/admin-ui-react'
+import { ThemeProvider } from '@vtex/admin-ui-react'
 import type { ReactElement } from 'react'
 import { renderHook, act } from '@testing-library/react-hooks'
 import userEvent from '@testing-library/user-event'
 
 expect.extend(toHaveNoViolations)
-
-const [ThemeProvider] = createSystem()
 
 function render(ui: ReactElement, options?: Omit<RenderOptions, 'queries'>) {
   return baseRender(ui, { wrapper: ThemeProvider, ...options })

--- a/packages/gatsby-plugin-admin-ui/src/provider.js
+++ b/packages/gatsby-plugin-admin-ui/src/provider.js
@@ -1,11 +1,5 @@
 import { createElement } from 'react'
-import { createSystem } from '@vtex/admin-ui'
-
-import theme from './theme'
-
-const [ThemeProvider] = createSystem({
-  experimentalTheme: theme,
-})
+import { ThemeProvider } from '@vtex/admin-ui'
 
 export function wrapRootElement(args) {
   const { element } = args


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Export ThemeProvider without using `createSystem()`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
