### PR TITLE
fix(tooltip): avoid "submit" as the default type of the trigger button

### DIFF
--- a/packages/admin-ui/src/tooltip/tooltip-trigger.tsx
+++ b/packages/admin-ui/src/tooltip/tooltip-trigger.tsx
@@ -6,9 +6,15 @@ import { Center } from '../center'
 
 export const TooltipTrigger = createComponent<'button', TooltipTriggerOptions>(
   (props) => {
-    const { bleedX = false, bleedY = false, ...buttonProps } = props
+    const {
+      bleedX = false,
+      bleedY = false,
+      type = 'button',
+      ...buttonProps
+    } = props
 
     return useElement('button', {
+      type,
       ...buttonProps,
       baseStyle: {
         ...style.tooltipTriggerWrapper,


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Avoid "submit" as the default type of the trigger button

#### What problem is this solving?
For most browsers the default type of button is "submit", so to avoid a tooltip triggering a submit inside a form, we should set the default type of to "button" (tooltip inner button).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
