### PR TITLE
fix(selection tree): avoid infinite re-render when the items list is …

### DIFF
--- a/packages/admin-ui/src/components/SelectionTree/state.ts
+++ b/packages/admin-ui/src/components/SelectionTree/state.ts
@@ -54,7 +54,7 @@ export function useSelectionTreeState<T>(
     () =>
       selected.length && selected.length !== ids.length
         ? 'indeterminate'
-        : selected.length === ids.length,
+        : ids.length > 0 && selected.length === ids.length,
     [selected, ids]
   )
 
@@ -90,6 +90,7 @@ export function useSelectionTreeState<T>(
   useEffect(
     function updateRootOnToggleItems() {
       if (
+        ids.length > 0 &&
         selectedItems instanceof Array &&
         selectedItems.length === ids.length
       ) {


### PR DESCRIPTION
…empty

<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Avoid infinite `SelectionTree` re-render when the items length changes from 0 to N.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
