### PR TITLE
test(chromatic): disable snapshot generation globally

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@ import { themeDecorator } from './themeDecorator'
 
 export const parameters = {
   controls: { expanded: true },
+  chromatic: { disableSnapshot: true },
   layout: 'fullscreen',
 }
 

--- a/packages/admin-ui/src/button/button.stories.tsx
+++ b/packages/admin-ui/src/button/button.stories.tsx
@@ -91,3 +91,47 @@ Bleed.args = {
   disabled: false,
   loading: false,
 }
+
+export function UITests() {
+  return (
+    <Box>
+      <Box>
+        <Button disabled>Disabled</Button>
+        <Button loading>Loading</Button>
+      </Box>
+
+      <Box>
+        <Button>Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="tertiary">Tertiary</Button>
+        <Button variant="neutralTertiary">Neutral Tertiary</Button>
+        <Button variant="critical">critical</Button>
+        <Button variant="criticalSecondary">Secondary</Button>
+        <Button variant="criticalTertiary">Tertiary</Button>
+      </Box>
+
+      <Box>
+        <Button>Normal</Button>
+        <Button size="large">Large</Button>
+      </Box>
+
+      <Box>
+        <Button icon={<IconX />}>Icon start</Button>
+        <Button icon={<IconX />} iconPosition="end">
+          Icon end
+        </Button>
+        <Button aria-label="Icon only test" icon={<IconX />} />
+      </Box>
+
+      <Box csx={{ padding: '$xl' }}>
+        <Button bleedX bleedY>
+          Bleed
+        </Button>
+      </Box>
+    </Box>
+  )
+}
+
+UITests.parameters = {
+  chromatic: { disableSnapshot: false },
+}

--- a/packages/admin-ui/src/button/button.stories.tsx
+++ b/packages/admin-ui/src/button/button.stories.tsx
@@ -94,41 +94,31 @@ Bleed.args = {
 
 export function UITests() {
   return (
-    <Box>
-      <Box>
-        <Button disabled>Disabled</Button>
-        <Button loading>Loading</Button>
-      </Box>
+    <>
+      <Button disabled>Disabled</Button>
+      <Button loading>Loading</Button>
 
-      <Box>
-        <Button>Primary</Button>
-        <Button variant="secondary">Secondary</Button>
-        <Button variant="tertiary">Tertiary</Button>
-        <Button variant="neutralTertiary">Neutral Tertiary</Button>
-        <Button variant="critical">critical</Button>
-        <Button variant="criticalSecondary">Secondary</Button>
-        <Button variant="criticalTertiary">Tertiary</Button>
-      </Box>
+      <Button>Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="tertiary">Tertiary</Button>
+      <Button variant="neutralTertiary">Neutral Tertiary</Button>
+      <Button variant="critical">critical</Button>
+      <Button variant="criticalSecondary">Secondary</Button>
+      <Button variant="criticalTertiary">Tertiary</Button>
 
-      <Box>
-        <Button>Normal</Button>
-        <Button size="large">Large</Button>
-      </Box>
+      <Button>Normal</Button>
+      <Button size="large">Large</Button>
 
-      <Box>
-        <Button icon={<IconX />}>Icon start</Button>
-        <Button icon={<IconX />} iconPosition="end">
-          Icon end
-        </Button>
-        <Button aria-label="Icon only test" icon={<IconX />} />
-      </Box>
+      <Button icon={<IconX />}>Icon start</Button>
+      <Button icon={<IconX />} iconPosition="end">
+        Icon end
+      </Button>
+      <Button aria-label="Icon only test" icon={<IconX />} />
 
-      <Box csx={{ padding: '$xl' }}>
-        <Button bleedX bleedY>
-          Bleed
-        </Button>
-      </Box>
-    </Box>
+      <Button bleedX bleedY>
+        Bleed
+      </Button>
+    </>
   )
 }
 


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

This PR disabled the generation of chromatic snapshots globally. This means that once we update the component stories we can set it as ready to be tested on chromatic and adopt this tool usage incrementally.

[Detailed info](https://www.chromatic.com/docs/ignoring-elements#ignore-stories)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
