### PR TITLE
fix(table): set fixed column position when window is resized

### DIFF
--- a/packages/admin-ui/src/table/components/styles/table.styles.ts
+++ b/packages/admin-ui/src/table/components/styles/table.styles.ts
@@ -19,7 +19,6 @@ const getColumnWidth = (column: TableColumn<any>) => {
 
 export const baseline = ({ columns }: RowOptions) =>
   style({
-    position: 'relative',
     display: 'grid',
     overflow: 'auto',
     gridTemplateColumns: columns.map(getColumnWidth).join(' '),

--- a/packages/admin-ui/src/table/components/table-cell.tsx
+++ b/packages/admin-ui/src/table/components/table-cell.tsx
@@ -40,11 +40,25 @@ function _TableCell<T>(props: TableCellProps<T>) {
   const ref = useRef<HTMLTableCellElement>(null)
 
   useEffect(() => {
-    if (!ref?.current || !column?.fixed) {
-      return
+    const setCellPosition = () => {
+      if (!ref?.current || !column?.fixed) {
+        return
+      }
+
+      const { previousElementSibling } = ref.current
+      const relativeLeftPosition =
+        previousElementSibling?.getBoundingClientRect().width ?? 0
+
+      ref.current.style.left = `${relativeLeftPosition}px`
     }
 
-    ref.current.style.left = `${ref.current.offsetLeft}px`
+    setCellPosition()
+
+    window.addEventListener('resize', setCellPosition, false)
+
+    return () => {
+      window.removeEventListener('resize', setCellPosition, false)
+    }
   }, [])
 
   const resolvedClassName = column?.fixed


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
Set fixed column position when window is resized

#### What problem is this solving?
Avoid fix columns with the wrong position when the window is resized and avoid menu component from getting stuck on the table

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
