### PR TITLE
fix(datepicker): make datepicker i18n depend only on the passed locale

### DIFF
--- a/packages/admin-ui/src/calendar/calendar-state.ts
+++ b/packages/admin-ui/src/calendar/calendar-state.ts
@@ -71,7 +71,7 @@ export function useCalendarState(
 
   // Get 2D Date arrays in 7 days a week format
   const daysInMonth = useMemo(() => {
-    let monthStartsAt = (startOfMonth(currentMonth).getDay() - weekStart) % 7
+    let monthStartsAt = (startOfMonth(currentMonth).getDay() % 7) - weekStart
 
     if (monthStartsAt < 0) {
       monthStartsAt += 7
@@ -79,8 +79,14 @@ export function useCalendarState(
 
     const days = getDaysInMonth(currentMonth)
     const weeksInMonth = Math.ceil((monthStartsAt + days) / 7)
+    const daysInMonthArray = generateDaysInMonthArray(
+      month,
+      monthStartsAt,
+      weeksInMonth,
+      year
+    )
 
-    return generateDaysInMonthArray(month, monthStartsAt, weeksInMonth, year)
+    return daysInMonthArray
   }, [month, year, currentMonth, weekStart])
 
   const isInvalidDateRange = useCallback(

--- a/packages/admin-ui/src/calendar/utils.ts
+++ b/packages/admin-ui/src/calendar/utils.ts
@@ -67,9 +67,8 @@ export function generateDaysInMonthArray(
     .reduce((weeks: Date[][], _, weekIndex) => {
       const daysInWeek = [0, 1, 2, 3, 4, 5, 6].reduce(
         (days: Date[], dayIndex) => {
-          const day = weekIndex * 7 + dayIndex - monthStartsAt + 2
-          const utcDate = toUTCString(new Date(year, month, day))
-          const cellDate = new Date(utcDate)
+          const day = weekIndex * 7 + (dayIndex - monthStartsAt) + 1
+          const cellDate = new Date(year, month, day)
 
           return [...days, cellDate]
         },

--- a/packages/admin-ui/src/date-picker/date-picker.stories.tsx
+++ b/packages/admin-ui/src/date-picker/date-picker.stories.tsx
@@ -105,6 +105,7 @@ Internationalized.argTypes = {
   locale: {
     options: [
       'en-US',
+      'en-GB',
       'pt-BR',
       'ko-KR',
       'ja-JP',

--- a/packages/admin-ui/src/i18n/use-region.ts
+++ b/packages/admin-ui/src/i18n/use-region.ts
@@ -6,11 +6,5 @@ import { useLocale } from '@react-aria/i18n'
 export function useRegion(): string {
   const { locale } = useLocale()
 
-  // If the Intl.Locale API is available, use it to get the region for the locale.
-  if ((Intl as any).Locale) {
-    return new (Intl as any).Locale(locale).maximize().region
-  }
-
-  // If not, just try splitting the string.
   return locale.split('-')[1]
 }


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?

The datepicker i18n will now depend only on the passed locale, not the browser intl API. This will give more control over the observed date.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
