### PR TITLE
feat: add disabled reason tooltip to menu-item

### DIFF
--- a/packages/admin-ui/src/menu/menu-item-wrapper.tsx
+++ b/packages/admin-ui/src/menu/menu-item-wrapper.tsx
@@ -2,16 +2,25 @@ import React from 'react'
 import type { ReactNode } from 'react'
 
 import { Box } from '../box'
+import { Tooltip } from '../tooltip'
 import * as style from './menu.style'
 
-export const MenuItemWrapper = (props: MenuItemWrapperProps) =>
-  props.disabled ? (
-    <Box csx={style.disabledItemWrapper}>{props.children}</Box>
-  ) : (
-    <>{props.children}</>
-  )
+export const MenuItemWrapper = (props: MenuItemWrapperProps) => {
+  const { children, disabled, disabledHint } = props
+
+  if (disabled && disabledHint) {
+    return (
+      <Tooltip text={disabledHint}>
+        <Box csx={style.disabledItemWrapper}>{children}</Box>
+      </Tooltip>
+    )
+  }
+
+  return <>{children}</>
+}
 
 export type MenuItemWrapperProps = {
   disabled?: boolean
+  disabledHint?: string
   children: ReactNode
 }

--- a/packages/admin-ui/src/menu/menu-item.tsx
+++ b/packages/admin-ui/src/menu/menu-item.tsx
@@ -16,10 +16,19 @@ export const MenuItem = createComponent<
   typeof AriakitMenuItem,
   MenuItemOptions
 >((props) => {
-  const { icon, label, critical, disabled, onClick, ...itemProps } = props
+  const {
+    icon,
+    label,
+    critical,
+    disabled,
+    disabledHint,
+    onClick,
+    ...itemProps
+  } = props
 
   return useElement(MenuItemWrapper, {
     disabled,
+    disabledHint,
     children: useElement(AriakitMenuItem, {
       disabled,
       onClick,
@@ -54,6 +63,10 @@ export type MenuItemOptions = {
    * Item label
    */
   label: ReactNode
+  /**
+   * Text to show on hover at disabled menu
+   */
+  disabledHint?: string
   /**
    * Item click event
    */

--- a/packages/admin-ui/src/menu/menu.stories.tsx
+++ b/packages/admin-ui/src/menu/menu.stories.tsx
@@ -75,7 +75,12 @@ export const IconOnly = () => {
       <>
         <MenuButton state={menuState} labelHidden />
         <Menu state={menuState}>
-          <MenuItem label="Create" icon={<IconPlus />} disabled />
+          <MenuItem
+            label="Create"
+            icon={<IconPlus />}
+            disabled
+            disabledHint="You don't have permission"
+          />
           <MenuItem label="Edit" icon={<IconPencil />} />
           <MenuItem label="Download" icon={<IconArrowLineDown />} />
           <MenuDivider />

--- a/packages/admin-ui/src/menu/menu.style.ts
+++ b/packages/admin-ui/src/menu/menu.style.ts
@@ -61,7 +61,7 @@ export const popoverContainer = style({
   bg: '$primary',
   border: '$neutral',
   boxShadow: '$overlay.center',
-  zIndex: 999,
+  zIndex: '$z-10',
 })
 
 export const popoverChildren = style({

--- a/packages/admin-ui/src/tooltip/tooltip.tsx
+++ b/packages/admin-ui/src/tooltip/tooltip.tsx
@@ -15,7 +15,7 @@ import { TooltipTrigger } from './tooltip-trigger'
 /**
  * Popup that displays information related to an element on :focus (by keyboard) or :hover (by mouse)
  * @example
- * <Tooltip label="Label" />
+ * <Tooltip text="Text" />
  */
 export function Tooltip(props: TooltipProps) {
   const {


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
- Add disabled hint to show tooltip at menu-items disabled

#### What problem is this solving?
- Sometimes the user don't know the reason why the menu-item is disabled, we think about add the Tooltip component to improve the user experience.

#### How should this be manually tested?
- run `yarn storybook` and go to menu-item, add some `disabled` and `disabledHint` prop to the component

#### Screenshots or example usage

https://user-images.githubusercontent.com/23361175/217233318-5d5f61b2-8d30-41ba-8e1a-336f2f600d36.mov



#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
