### PR TITLE
feat: add disabled reason tooltip to tabs

### DIFF
--- a/packages/admin-ui/src/tab/stories/tabs.stories.tsx
+++ b/packages/admin-ui/src/tab/stories/tabs.stories.tsx
@@ -38,6 +38,25 @@ export function WithPanel() {
   )
 }
 
+export function WithDisabledHint() {
+  const state = useTabState()
+
+  return (
+    <>
+      <TabList state={state}>
+        <Tab>Tab 1</Tab>
+        <Tab disabled disabledHint="You don't have permission">
+          Tab 2
+        </Tab>
+      </TabList>
+      <TabPanelList state={state}>
+        <TabPanel>Panel 1</TabPanel>
+        <TabPanel>Panel 2</TabPanel>
+      </TabPanelList>
+    </>
+  )
+}
+
 export function WithId() {
   const state = useTabState()
 

--- a/packages/admin-ui/src/tab/tab-wrapper.tsx
+++ b/packages/admin-ui/src/tab/tab-wrapper.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import type { ReactNode } from 'react'
+
+import { Box } from '../box'
+import { Tooltip } from '../tooltip'
+
+export const TabWrapper = (props: TabWrapperProps) => {
+  const { children, disabled, disabledHint } = props
+
+  if (disabled && disabledHint) {
+    return (
+      <Tooltip text={disabledHint}>
+        <Box>{children}</Box>
+      </Tooltip>
+    )
+  }
+
+  return <>{children}</>
+}
+
+export type TabWrapperProps = {
+  disabled?: boolean
+  disabledHint?: string
+  children: ReactNode
+}

--- a/packages/admin-ui/src/tab/tab.tsx
+++ b/packages/admin-ui/src/tab/tab.tsx
@@ -2,13 +2,17 @@ import { Tab as AriakitTab } from 'ariakit'
 import { createComponent, useElement } from '@vtex/admin-ui-react'
 import type { ReactNode } from 'react'
 import type { TabState } from './tab.state'
+import { TabWrapper } from './tab-wrapper'
 
 import * as style from './tabs.style'
 
 export const Tab = createComponent<typeof AriakitTab, TabOptions>((props) => {
-  return useElement(AriakitTab, {
+  return useElement(TabWrapper, {
     ...props,
-    baseStyle: style.tab,
+    children: useElement(AriakitTab, {
+      ...props,
+      baseStyle: style.tab,
+    }),
   })
 })
 
@@ -16,6 +20,7 @@ export interface TabOptions {
   state?: TabState
   id?: string
   children?: ReactNode
+  disabledHint?: string
 }
 
 export type TabProps = React.ComponentPropsWithRef<typeof Tab>

--- a/packages/admin-ui/src/tab/tabs.style.ts
+++ b/packages/admin-ui/src/tab/tabs.style.ts
@@ -29,6 +29,11 @@ export const tab = style({
     borderBottom: '$mainSelected',
     borderBottomWidth: tabBorderBottomWidth,
   },
+  '&[aria-disabled="true"]': {
+    cursor: 'not-allowed',
+    borderBottom: 'none',
+    fg: '$disabled',
+  },
   ...focusVisible('main'),
 })
 


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
- Add disabled hint to show tooltip at disabled Tab
- Add styles to disabled Tab
- Update tab stories

#### What problem is this solving?
- Sometimes the user don't know the reason why the Tab is disabled, we think about add the Tooltip component to improve the user experience.

#### How should this be manually tested?
- run `yarn storybook` and go to Tab with Disabled Hint

#### Screenshots or example usage

https://user-images.githubusercontent.com/23361175/217254830-5691b877-6d11-4b42-9ad8-324343067fb6.mov



#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

