### PR TITLE
fix(tabs): update disabled Tabs' styles

### DIFF
--- a/packages/admin-ui/src/tab/stories/tabs.stories.tsx
+++ b/packages/admin-ui/src/tab/stories/tabs.stories.tsx
@@ -54,3 +54,20 @@ export function WithId() {
     </>
   )
 }
+
+export function WithDisabled() {
+  const state = useTabState()
+
+  return (
+    <>
+      <TabList state={state}>
+        <Tab disabled>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+      </TabList>
+      <TabPanelList state={state}>
+        <TabPanel>Panel 1</TabPanel>
+        <TabPanel>Panel 2</TabPanel>
+      </TabPanelList>
+    </>
+  )
+}

--- a/packages/admin-ui/src/tab/tabs.style.ts
+++ b/packages/admin-ui/src/tab/tabs.style.ts
@@ -29,6 +29,11 @@ export const tab = style({
     borderBottom: '$mainSelected',
     borderBottomWidth: tabBorderBottomWidth,
   },
+  '&[aria-disabled="true"]': {
+    cursor: 'not-allowed',
+    borderBottom: 'none',
+    fg: '$disabled',
+  },
   ...focusVisible('main'),
 })
 


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
- The disabled styles from tabs is not showing to the user that the tab is not enabled.

#### What problem is this solving?
- Better UX when using disabled tabs

#### How should this be manually tested?
<!--- Usually `yarn and yarn test`, but feel encouraged to add a more descriptive explanation. -->
- `yarn dev && yarn storybook`, then go to disabled Tabs stories

#### Screenshots or example usage
**Before this PR:**

https://user-images.githubusercontent.com/23361175/218422380-9a504765-e20d-4879-bcf1-fa587a0a72cd.mov

**After:**

https://user-images.githubusercontent.com/23361175/218422466-eb851d33-1a79-4cc8-845b-501d7d0b5d5d.mov



#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
