### PR TITLE
Fix: wrong spacing in control groups

### DIFF
--- a/packages/admin-ui/src/checkbox/checkbox-group.tsx
+++ b/packages/admin-ui/src/checkbox/checkbox-group.tsx
@@ -36,7 +36,6 @@ export const CheckboxGroup = forwardRef(function CheckboxGroup(
         <Stack
           direction={direction}
           space="$space-4"
-          className={csx({ paddingY: '$space-1' })}
         >
           {children}
         </Stack>

--- a/packages/admin-ui/src/form-control/form-control.tsx
+++ b/packages/admin-ui/src/form-control/form-control.tsx
@@ -7,7 +7,7 @@ export function FormControl(props: FormGroupOptions) {
   const { children, className } = props
 
   return (
-    <Stack space="$space-1" className={className}>
+    <Stack space="$space-3" className={className}>
       {children}
     </Stack>
   )

--- a/packages/admin-ui/src/page/page.css.ts
+++ b/packages/admin-ui/src/page/page.css.ts
@@ -107,12 +107,12 @@ export const pageContentTheme = csx({
     paddingBottom: '3rem',
   },
   [dataAttr('layout', 'standard')]: {
-    maxWidth: '77rem',
+    maxWidth: '75rem',
     paddingTop: '2.5rem',
     paddingBottom: '5rem',
   },
   [dataAttr('layout', 'narrow')]: {
-    maxWidth: '52rem',
+    maxWidth: '50rem',
     paddingTop: '3rem',
     paddingBottom: '8rem',
   },

--- a/packages/admin-ui/src/radio/radio-group.tsx
+++ b/packages/admin-ui/src/radio/radio-group.tsx
@@ -44,7 +44,6 @@ export const RadioGroup = forwardRef(function RadioGroup(
         <Stack
           direction={direction}
           space="$space-4"
-          className={csx({ paddingY: '$space-1' })}
         >
           {children}
         </Stack>

--- a/packages/admin-ui/src/radio/radio.tsx
+++ b/packages/admin-ui/src/radio/radio.tsx
@@ -20,7 +20,7 @@ export const Radio = forwardRef(function Radio(
 
   return (
     <FormControl>
-      <Inline hSpace="$space-2" vSpace="" spaceInside="true">
+      <Inline hSpace="$space-2" vSpace="" spaceInside>
         <RadioButton ref={ref} {...radioButtonProps} id={id} />
         <Stack space="$space-05">
           <Label htmlFor={id} className={labelTheme}>

--- a/packages/admin-ui/src/radio/radio.tsx
+++ b/packages/admin-ui/src/radio/radio.tsx
@@ -20,7 +20,7 @@ export const Radio = forwardRef(function Radio(
 
   return (
     <FormControl>
-      <Inline hSpace="$space-2" vSpace="">
+      <Inline hSpace="$space-2" vSpace="" spaceInside="true">
         <RadioButton ref={ref} {...radioButtonProps} id={id} />
         <Stack space="$space-05">
           <Label htmlFor={id} className={labelTheme}>


### PR DESCRIPTION
#### What problem is this solving?
Wrong spacing in control groups (radio and checkbox groups)
