### PR TITLE
TableCell: invalid value for prop data-horizontal-scroll

### DIFF
--- a/packages/admin-ui/src/table/components/table-cell.tsx
+++ b/packages/admin-ui/src/table/components/table-cell.tsx
@@ -76,7 +76,7 @@ function _TableCell<T>(props: TableCellProps<T>) {
       data-clickable={!!onClick}
       data-fixed={column?.fixed}
       data-last-fixed={isLastFixedColumn}
-      data-horizontal-scroll={hasHorizontalScroll}
+      data-horizontal-scroll={hasHorizontalScroll()}
       className={cx(tableCellTheme, resolvedClassName)}
     >
       <div className={innerContainerTheme}>{children}</div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Fixes the React warning about the invalid value for prop `data-horizontal-scroll`

```bash
Warning: Invalid value for prop `data-horizontal-scroll` on <td> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://reactjs.org/link/attribute-behavior
```

#### What problem is this solving?

- Fixes the value, which was invalid before, so it couldn't be used.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
