### PR TITLE
Fix form control spacing

### DIFF
--- a/packages/admin-ui/src/form-control/form-control.tsx
+++ b/packages/admin-ui/src/form-control/form-control.tsx
@@ -7,7 +7,7 @@ export function FormControl(props: FormGroupOptions) {
   const { children, className } = props
 
   return (
-    <Stack space="$space-3" className={className}>
+    <Stack space="$space-1" className={className}>
       {children}
     </Stack>
   )


### PR DESCRIPTION
I wanted to change the space only on the Radio Group and Checkbox group components, but I ended up breaking Input components. I think "Form Control" should only be used by Radio Group and Checkbox Group components, and there should be a "Form Input" component for the inputs. Radio and Checkbox are controls and the other fields are inputs.

But since it might take sometime to make this change, and the inputs are broken, I'm reverting my previous commit in this PR.

<img width="1049" alt="image" src="https://github.com/vtex/admin-ui/assets/8797476/579718d4-b116-416f-9639-e598ae126942">
